### PR TITLE
feat: Claude Code-style UX overhaul — inline loading, Ctrl+key bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-iptv"
-version = "4.2.1"
+version = "4.3.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-iptv"
-version = "4.2.1"
+version = "4.3.0"
 edition = "2021"
 default-run = "matrix-iptv"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -138,6 +138,7 @@ pub struct App {
     pub current_screen: CurrentScreen,
     pub input_mode: InputMode,
     pub should_quit: bool,
+    pub needs_clear: bool,
 
     // Home / Accounts
     pub account_list_state: ListState,
@@ -409,6 +410,7 @@ impl App {
             current_screen: CurrentScreen::Home,
             input_mode: InputMode::Normal,
             should_quit: false,
+            needs_clear: false,
             session: SessionState {
                 cached_user_timezone: cached_tz,
                 selected_account_index: 0,

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -98,21 +98,138 @@ pub async fn handle_key_event(
         return Ok(InputResult::Continue);
     }
 
-    // Priority 0: Loading State Handling (Cancellation)
+    // Global Ctrl+Key Bindings (Claude Code style)
+    let is_ctrl_c = key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
+    let is_ctrl_l = key.code == KeyCode::Char('l') && key.modifiers.contains(KeyModifiers::CONTROL);
+    let is_ctrl_r = key.code == KeyCode::Char('r') && key.modifiers.contains(KeyModifiers::CONTROL);
+    let is_ctrl_g = key.code == KeyCode::Char('g') && key.modifiers.contains(KeyModifiers::CONTROL);
+    let is_ctrl_b = key.code == KeyCode::Char('b') && key.modifiers.contains(KeyModifiers::CONTROL);
+
+    // Ctrl+C: Cancel loading or quit confirmation
+    if is_ctrl_c {
+        if app.session.state_loading {
+            app.session.state_loading = false;
+            app.session.loading_message = None;
+            app.session.loading_cancelled = true;
+            app.login_error = None;
+            return Ok(InputResult::Continue);
+        } else {
+            app.should_quit = true;
+            return Ok(InputResult::Quit);
+        }
+    }
+
+    // Ctrl+L: Force redraw/clear screen
+    if is_ctrl_l {
+        app.needs_clear = true;
+        return Ok(InputResult::Continue);
+    }
+
+    // Ctrl+R: Reverse search (alias for Ctrl+Space)
+    if is_ctrl_r {
+        let on_home = app.current_screen == CurrentScreen::Home;
+        app.previous_screen = Some(app.current_screen.clone());
+        app.current_screen = CurrentScreen::GlobalSearch;
+        app.search_mode = true;
+        app.search_state.query.clear();
+        app.last_search_query.clear();
+        app.update_search();
+        app.show_matrix_rain = false;
+        app.matrix_rain_screensaver_mode = false;
+        if on_home && app.global_all_streams.is_empty() {
+            if let Some(acc) = app.config.accounts.get(app.session.selected_account_index) {
+                let tx = tx.clone();
+                let base_url = acc.base_url.clone();
+                let username = acc.username.clone();
+                let password = acc.password.clone();
+                let account_type = acc.account_type;
+                tokio::spawn(async move {
+                    match account_type {
+                        crate::config::AccountType::M3uUrl => {
+                            let client = crate::api::M3uClient::new(base_url);
+                            if let Ok((true, _, _)) = client.authenticate().await {
+                                let iptv_client = crate::api::IptvClient::M3u(client);
+                                let _ = tx
+                                    .send(AsyncAction::LoginSuccess(iptv_client, None, None))
+                                    .await;
+                            }
+                        }
+                        _ => {
+                            let client =
+                                crate::api::XtreamClient::new(base_url, username, password);
+                            if let Ok((true, _, _)) = client.authenticate().await {
+                                let iptv_client = crate::api::IptvClient::Xtream(client.clone());
+                                let _ = tx
+                                    .send(AsyncAction::LoginSuccess(iptv_client, None, None))
+                                    .await;
+                            }
+                        }
+                    }
+                });
+            }
+        }
+        return Ok(InputResult::Continue);
+    }
+
+    // Ctrl+G: Toggle guide popup
+    if is_ctrl_g {
+        if app.show_guide.is_some() {
+            app.show_guide = None;
+        } else {
+            app.show_guide = Some(Guide::WhatIsApp);
+            app.guide_scroll = 0;
+        }
+        return Ok(InputResult::Continue);
+    }
+
+    // Ctrl+B: Background operation (stub - shows a subtle hint)
+    if is_ctrl_b {
+        // Stub: could be used for background loading in the future
+        return Ok(InputResult::Continue);
+    }
+
+    // Priority 0: Loading State Handling (Allow navigation while loading)
     if app.session.state_loading {
-        // While loading, we trap input. Allow Esc to cancel.
+        // Allow Esc to cancel loading
         if key.code == KeyCode::Esc {
             app.session.state_loading = false;
             app.session.loading_message = None;
-            app.login_error = None; // clear any previous error
-                                    // If we were connecting, we just stop waiting for the result.
-                                    // The background task will still complete but its result will be ignored
-                                    // because state_loading is false (async actions check this or we just overwrite)
-                                    // But to be safe, let's just let the user regain control.
+            app.session.loading_cancelled = true;
+            app.login_error = None;
             return Ok(InputResult::Continue);
         }
-        // ignore other keys while loading
-        return Ok(InputResult::Continue);
+
+        // Allow navigation keys while loading (j/k/h/l, arrows, PgUp/PgDn, Home/End, g/G, Ctrl+D/U)
+        // Block action keys that would trigger operations (Enter, /, v, i, etc.)
+        let is_navigation = matches!(
+            key.code,
+            KeyCode::Char('j')
+                | KeyCode::Char('k')
+                | KeyCode::Char('h')
+                | KeyCode::Char('l')
+                | KeyCode::Char('g')
+                | KeyCode::Char('G')
+                | KeyCode::Up
+                | KeyCode::Down
+                | KeyCode::Left
+                | KeyCode::Right
+                | KeyCode::PageUp
+                | KeyCode::PageDown
+                | KeyCode::Home
+                | KeyCode::End
+        );
+        let is_ctrl_nav = key.modifiers.contains(KeyModifiers::CONTROL)
+            && matches!(
+                key.code,
+                KeyCode::Char('d') | KeyCode::Char('u') | KeyCode::Char('D') | KeyCode::Char('U')
+            );
+
+        if is_navigation || is_ctrl_nav {
+            // Let the navigation through to the screen-specific handlers
+        } else {
+            // Block action keys during loading
+            return Ok(InputResult::Continue);
+        }
     }
 
     // Priority 1: Help Popup

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,6 +213,12 @@ async fn run_app<B: ratatui::backend::Backend>(
                 .draw(|f| ui::ui(f, app))
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
             needs_redraw = false;
+
+            // Handle Ctrl+L clear request
+            if app.needs_clear {
+                let _ = terminal.clear();
+                app.needs_clear = false;
+            }
         }
 
         // 1. Check for Async Actions (Non-blocking)

--- a/src/state.rs
+++ b/src/state.rs
@@ -69,6 +69,8 @@ pub struct SessionState {
     pub loading_progress: Option<LoadingProgress>,
     /// Loading animation tick
     pub loading_tick: u64,
+    /// Flag indicating user cancelled loading
+    pub loading_cancelled: bool,
     /// Selected account index
     pub selected_account_index: usize,
     /// Max category name length for UI alignment

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -1,14 +1,41 @@
 use crate::app::{App, CurrentScreen, InputMode, SettingsState};
 use crate::ui::colors::{MATRIX_GREEN, MODERN_BG, SOFT_GREEN, TEXT_DIM, TEXT_SECONDARY};
+use crate::ui::loading::get_loading_status_line;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Style, Stylize},
+    style::{Color, Style, Stylize},
     text::{Line, Span},
     widgets::Paragraph,
     Frame,
 };
 
 pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
+    // If loading, render inline loading status instead of normal hints
+    if let Some(loading_line) = get_loading_status_line(app) {
+        render_loading_footer(f, app, area, loading_line);
+        return;
+    }
+
+    render_normal_footer(f, app, area);
+}
+
+fn render_loading_footer(f: &mut Frame, _app: &App, area: Rect, loading_line: Line<'static>) {
+    use ratatui::symbols::border;
+    use ratatui::widgets::{Block, Borders};
+
+    let bar_block = Block::default()
+        .borders(Borders::TOP)
+        .border_set(border::ROUNDED)
+        .border_style(Style::default().fg(SOFT_GREEN))
+        .bg(MODERN_BG);
+    let bar_inner = bar_block.inner(area);
+    f.render_widget(bar_block, area);
+
+    let p = Paragraph::new(loading_line).alignment(Alignment::Left);
+    f.render_widget(p, bar_inner);
+}
+
+fn render_normal_footer(f: &mut Frame, app: &App, area: Rect) {
     let key_style = Style::default().fg(MATRIX_GREEN);
     let label_style = Style::default().fg(TEXT_SECONDARY);
     let sep_style = Style::default().fg(TEXT_DIM);
@@ -32,6 +59,8 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
     match app.current_screen {
         CurrentScreen::Home => {
             hint!("q", "quit");
+            hint!("ctrl+c", "quit");
+            hint!("ctrl+l", "redraw");
             hint!("enter", "load");
             hint!("n", "add");
             hint!("e", "edit");
@@ -127,6 +156,7 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
         }
         _ => {
             hint!("q", "quit");
+            hint!("ctrl+c", "quit");
             hint!("esc", "back");
         }
     }
@@ -151,6 +181,16 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
         }
         _ => {}
     }
+
+    // Add connection status indicator
+    let status_indicator = if app.session.is_connected() {
+        Span::styled(" ● ", Style::default().fg(Color::Rgb(0, 255, 65)))
+    } else if app.session.state_loading {
+        Span::styled(" ◐ ", Style::default().fg(Color::Rgb(255, 200, 80)))
+    } else {
+        Span::styled(" ○ ", Style::default().fg(TEXT_DIM))
+    };
+    right_spans.insert(0, status_indicator);
 
     // Use bordered bottom bar
     use ratatui::symbols::border;

--- a/src/ui/loading.rs
+++ b/src/ui/loading.rs
@@ -1,218 +1,86 @@
 use crate::app::App;
 use crate::ui::colors::{MATRIX_GREEN, SOFT_GREEN, TEXT_DIM, TEXT_PRIMARY, TEXT_SECONDARY};
 use ratatui::{
-    layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
-    Frame,
 };
 
-struct LoadingPanel {
-    title: String,
-    headline: String,
-    detail: String,
-    raw_status: String,
+const BRAILLE_SPINNER: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+pub fn get_loading_status_line(app: &App) -> Option<Line<'static>> {
+    if !app.session.state_loading || app.session.loading_message.is_none() {
+        return None;
+    }
+
+    let tick = app.session.loading_tick;
+    let spinner = BRAILLE_SPINNER[(tick as usize) % BRAILLE_SPINNER.len()];
+
+    let panel = derive_loading_info(app);
+
+    let mut spans: Vec<Span> = Vec::new();
+
+    spans.push(Span::styled(
+        format!("{} ", spinner),
+        Style::default()
+            .fg(MATRIX_GREEN)
+            .add_modifier(Modifier::BOLD),
+    ));
+
+    spans.push(Span::styled(
+        format!("{} ", panel.verb),
+        Style::default()
+            .fg(TEXT_PRIMARY)
+            .add_modifier(Modifier::BOLD),
+    ));
+
+    if let Some(pct) = panel.percent {
+        let bar_width = 12usize.min(20).max(8);
+        let filled = (pct * bar_width) / 100;
+        let empty = bar_width.saturating_sub(filled);
+        let bar = format!(
+            "[{}{}]",
+            "█".repeat(filled.min(bar_width)),
+            "░".repeat(empty.min(bar_width))
+        );
+        spans.push(Span::styled(
+            format!("{} {:>3}% ", bar, pct),
+            Style::default().fg(SOFT_GREEN),
+        ));
+    }
+
+    if let Some((current, total)) = panel.counts {
+        spans.push(Span::styled(
+            format!("{}/{} ", current, total),
+            Style::default().fg(TEXT_SECONDARY),
+        ));
+    }
+
+    if let Some(eta) = &panel.eta {
+        spans.push(Span::styled(
+            format!("ETA {} ", eta),
+            Style::default().fg(SOFT_GREEN),
+        ));
+    }
+
+    spans.push(Span::styled("│  esc cancel", Style::default().fg(TEXT_DIM)));
+
+    Some(Line::from(spans))
+}
+
+struct LoadingInfo {
+    verb: String,
     percent: Option<usize>,
     counts: Option<(usize, usize)>,
     eta: Option<String>,
 }
 
-pub fn render_loading(f: &mut Frame, app: &App, area: Rect) {
-    if !app.session.state_loading {
-        return;
-    }
-
-    // Subtle overlay across the background
-    let row = "░".repeat(area.width as usize);
-    let lines = vec![Line::from(row.as_str()); area.height as usize];
-    let dim_paragraph =
-        Paragraph::new(lines).style(Style::default().fg(Color::DarkGray).bg(Color::Rgb(0, 0, 0)));
-    f.render_widget(dim_paragraph, area);
-
-    let panel = derive_loading_panel(app);
-
-    let popup_area = centered_rect(84, 12, area);
-    f.render_widget(Clear, popup_area);
-
-    use ratatui::symbols::border;
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_set(border::ROUNDED)
-        .border_style(Style::default().fg(MATRIX_GREEN))
-        .title(Span::styled(
-            panel.title.clone(),
-            Style::default()
-                .fg(MATRIX_GREEN)
-                .add_modifier(Modifier::BOLD),
-        ))
-        .title_alignment(Alignment::Center)
-        .style(Style::default().bg(Color::Rgb(0, 0, 0)));
-
-    f.render_widget(block, popup_area);
-
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .margin(1)
-        .constraints([
-            Constraint::Length(1),
-            Constraint::Length(2),
-            Constraint::Length(1),
-            Constraint::Length(2),
-            Constraint::Length(1),
-            Constraint::Min(0),
-            Constraint::Length(1),
-        ])
-        .split(popup_area);
-
-    let tick = app.session.loading_tick;
-
-    // Matrix style Katakana spinner and decoding effect
-    let katakana = [
-        'ｦ', 'ｧ', 'ｨ', 'ｩ', 'ｪ', 'ｫ', 'ｬ', 'ｭ', 'ｮ', 'ｯ', 'ｰ', 'ｱ', 'ｲ', 'ｳ', 'ｴ', 'ｵ', 'ｶ', 'ｷ',
-        'ｸ', 'ｹ', 'ｺ', 'ｻ', 'ｼ', 'ｽ', 'ｾ', 'ｿ', 'ﾀ', 'ﾁ', 'ﾂ', 'ﾃ', 'ﾄ', 'ﾅ', 'ﾆ', 'ﾇ', 'ﾈ', 'ﾉ',
-        'ﾊ', 'ﾋ', 'ﾌ', 'ﾍ', 'ﾎ', 'ﾏ', 'ﾐ', 'ﾑ', 'ﾒ', 'ﾓ', 'ﾔ', 'ﾕ', 'ﾖ', 'ﾗ', 'ﾘ', 'ﾙ', 'ﾚ', 'ﾛ',
-        'ﾜ', 'ﾝ',
-    ];
-    let spinner = katakana[(tick as usize) % katakana.len()];
-
-    let glitch_len = 8;
-    let mut glitch_str = String::with_capacity(glitch_len);
-    for i in 0..glitch_len {
-        let char_idx = (tick.wrapping_add((i * 13) as u64) as usize) % katakana.len();
-        glitch_str.push(katakana[char_idx]);
-    }
-
-    let hero = Paragraph::new(Line::from(vec![
-        Span::styled(
-            format!("{} ", spinner),
-            Style::default()
-                .fg(Color::Rgb(200, 255, 200))
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(
-            panel.headline.as_str(),
-            Style::default()
-                .fg(TEXT_PRIMARY)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(
-            format!(" [{}]", glitch_str),
-            Style::default().fg(MATRIX_GREEN),
-        ),
-    ]))
-    .alignment(Alignment::Left);
-    f.render_widget(hero, chunks[0]);
-
-    let detail = Paragraph::new(vec![
-        Line::from(Span::styled(
-            panel.detail.as_str(),
-            Style::default().fg(TEXT_SECONDARY),
-        )),
-        Line::from(Span::styled(
-            format!("raw status: {}", panel.raw_status),
-            Style::default().fg(TEXT_DIM),
-        )),
-    ])
-    .wrap(ratatui::widgets::Wrap { trim: true });
-    f.render_widget(detail, chunks[1]);
-
-    if let Some(pct) = panel.percent {
-        let bar_width = (popup_area.width as usize)
-            .saturating_sub(24)
-            .max(12)
-            .min(48);
-        let filled = (pct * bar_width) / 100;
-        let empty = bar_width.saturating_sub(filled);
-        let bar = format!("{}{}", "█".repeat(filled), "░".repeat(empty));
-        let ratio = panel
-            .counts
-            .map(|(current, total)| format!("{}/{}", current, total))
-            .unwrap_or_else(|| "sync".to_string());
-        let eta = panel
-            .eta
-            .clone()
-            .unwrap_or_else(|| "estimating...".to_string());
-
-        let bar_line = Paragraph::new(Line::from(vec![
-            Span::styled(format!("[{}]", bar), Style::default().fg(SOFT_GREEN)),
-            Span::styled(
-                format!("  {:>3}%", pct),
-                Style::default()
-                    .fg(TEXT_PRIMARY)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(format!("  {}", ratio), Style::default().fg(TEXT_SECONDARY)),
-            Span::styled(
-                format!("  time left {}", eta),
-                Style::default().fg(SOFT_GREEN),
-            ),
-        ]))
-        .alignment(Alignment::Left);
-        f.render_widget(bar_line, chunks[2]);
-    }
-
-    let status_line = Paragraph::new(vec![
-        Line::from(vec![
-            Span::styled("phase", Style::default().fg(TEXT_DIM)),
-            Span::styled("  first import sync", Style::default().fg(Color::White)),
-        ]),
-        Line::from(Span::styled(
-            "What takes time: download -> decode -> dedupe/filter -> build the browseable index.",
-            Style::default().fg(TEXT_SECONDARY),
-        )),
-    ])
-    .wrap(ratatui::widgets::Wrap { trim: true });
-    f.render_widget(status_line, chunks[3]);
-
-    let eta_hint = Paragraph::new(Line::from(Span::styled(
-        panel
-            .eta
-            .clone()
-            .map(|eta| format!("Estimated remaining time: {}", eta))
-            .unwrap_or_else(|| {
-                "Estimated remaining time: calculating from live progress...".to_string()
-            }),
-        Style::default().fg(MATRIX_GREEN),
-    )));
-    f.render_widget(eta_hint, chunks[4]);
-
-    let footer = Paragraph::new(Line::from(Span::styled(
-        "esc to cancel",
-        Style::default().fg(TEXT_DIM),
-    )))
-    .alignment(Alignment::Center);
-    f.render_widget(footer, chunks[6]);
-}
-
-fn centered_rect(percent_x: u16, height: u16, r: Rect) -> Rect {
-    let vertical_margin = r.height.saturating_sub(height) / 2;
-    let popup_layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(vertical_margin),
-            Constraint::Length(height),
-            Constraint::Min(0),
-        ])
-        .split(r);
-
-    let horizontal_margin = (100_u16.saturating_sub(percent_x)) / 2;
-    Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage(horizontal_margin),
-            Constraint::Percentage(percent_x),
-            Constraint::Min(0),
-        ])
-        .split(popup_layout[1])[1]
-}
-
-fn derive_loading_panel(app: &App) -> LoadingPanel {
+fn derive_loading_info(app: &App) -> LoadingInfo {
     let raw_status = app
         .session
         .loading_message
         .clone()
-        .unwrap_or_else(|| "Initializing system...".to_string());
+        .unwrap_or_else(|| "Processing...".to_string());
+
     let progress_pct = app
         .session
         .loading_progress
@@ -240,76 +108,39 @@ fn derive_loading_panel(app: &App) -> LoadingPanel {
         .and_then(|progress| progress.eta.as_ref().map(|d| format_duration(d.as_secs())))
         .or_else(|| extract_eta_seconds(&raw_status).map(format_duration));
 
-    let (headline, detail) = if raw_status.contains("Downloading playlist") {
-        (
-            "Downloading playlist payload".to_string(),
-            "Pulling the raw provider data down before it can be parsed into channels.".to_string(),
-        )
+    let verb = if raw_status.contains("Downloading playlist") {
+        "Downloading playlist".to_string()
     } else if raw_status.contains("Preparing memory mapping") || raw_status.contains("Received") {
-        (
-            "Staging playlist data in memory".to_string(),
-            "The payload is fully downloaded. Matrix IPTV is preparing it for fast decoding."
-                .to_string(),
-        )
+        "Staging data in memory".to_string()
     } else if raw_status.contains("Deserializing JSON") {
-        (
-            "Decoding provider response".to_string(),
-            "Turning the raw server payload into structured stream records.".to_string(),
-        )
+        "Decoding provider response".to_string()
     } else if raw_status.contains("Preprocessing")
         || raw_status.contains("Optimizing")
         || raw_status.contains("Refining metadata")
     {
-        (
-            "Cleaning and organizing channels".to_string(),
-            "Removing duplicates, applying playlist mode filters, and preparing metadata for browsing.".to_string(),
-        )
+        "Cleaning and organizing".to_string()
     } else if raw_status.contains("Sorting")
         || raw_status.contains("Linking UI")
         || raw_status.contains("Finalized")
     {
-        (
-            "Building the interactive index".to_string(),
-            "Final pass: sorting channels, wiring categories, and making the browser responsive."
-                .to_string(),
-        )
+        "Building index".to_string()
     } else if raw_status.contains("Loading all channels")
         || raw_status.contains("Fetching all channels")
     {
-        (
-            "Starting the first full channel sync".to_string(),
-            "The first import is the slow one because every live channel has to be fetched and indexed.".to_string(),
-        )
+        "Syncing channels".to_string()
     } else if raw_status.contains("Loading categories") {
-        (
-            "Loading provider categories".to_string(),
-            "Fetching the live category list so Matrix IPTV knows what it needs to scan next."
-                .to_string(),
-        )
+        "Loading categories".to_string()
     } else if raw_status.contains("Connecting to server")
         || raw_status.contains("Authenticating")
         || raw_status.contains("Processing Playlist")
     {
-        (
-            "Opening the provider session".to_string(),
-            "Connecting, authenticating, and preparing the first import pipeline.".to_string(),
-        )
+        "Connecting to server".to_string()
     } else {
-        (
-            "Processing your playlist".to_string(),
-            "Matrix IPTV is working through the provider data and will keep refining the ETA as more progress is available.".to_string(),
-        )
+        "Processing".to_string()
     };
 
-    let title = progress_pct
-        .map(|pct| format!(" initial sync  {}% ", pct))
-        .unwrap_or_else(|| " initial sync ".to_string());
-
-    LoadingPanel {
-        title,
-        headline,
-        detail,
-        raw_status,
+    LoadingInfo {
+        verb,
         percent: progress_pct,
         counts,
         eta,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -98,12 +98,7 @@ pub fn ui(f: &mut Frame, app: &mut App) {
         }
     }
 
-    // Overlays
-    if app.session.loading_message.is_some() {
-        loading::render_loading(f, app, area);
-    }
-
-    // Matrix Rain Overlay (Draws on top of everything except Help/Guide/Error if they need focus, but effectively screensaver covers all)
+    // Base Screens (Draws on top of everything except Help/Guide/Error if they need focus, but effectively screensaver covers all)
     // Actually screensaver should be on top of everything.
     if app.show_matrix_rain {
         #[cfg(not(target_arch = "wasm32"))]

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -63,6 +63,34 @@ pub fn render_help_popup(f: &mut Frame, area: Rect) {
         ]),
         Line::from(""),
         Line::from(vec![Span::styled(
+            "  global shortcuts",
+            Style::default()
+                .fg(TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        )]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  ctrl+c      ", Style::default().fg(MATRIX_GREEN)),
+            Span::styled("cancel / quit", Style::default().fg(TEXT_SECONDARY)),
+        ]),
+        Line::from(vec![
+            Span::styled("  ctrl+l      ", Style::default().fg(MATRIX_GREEN)),
+            Span::styled("clear screen", Style::default().fg(TEXT_SECONDARY)),
+        ]),
+        Line::from(vec![
+            Span::styled("  ctrl+r      ", Style::default().fg(MATRIX_GREEN)),
+            Span::styled("search", Style::default().fg(TEXT_SECONDARY)),
+        ]),
+        Line::from(vec![
+            Span::styled("  ctrl+g      ", Style::default().fg(MATRIX_GREEN)),
+            Span::styled("toggle guide", Style::default().fg(TEXT_SECONDARY)),
+        ]),
+        Line::from(vec![
+            Span::styled("  ctrl+space  ", Style::default().fg(MATRIX_GREEN)),
+            Span::styled("search", Style::default().fg(TEXT_SECONDARY)),
+        ]),
+        Line::from(""),
+        Line::from(vec![Span::styled(
             "  features",
             Style::default()
                 .fg(TEXT_PRIMARY)


### PR DESCRIPTION
## Summary

- **Inline loading status bar**: Replaced the full-screen loading overlay (84%×12 row popup with Katakana spinner) with a 1-row inline status bar in the footer. Uses braille spinner (⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏) + verb + progress bar + counts + ETA. Content panes remain visible and interactive during loading.
- **Unblocked navigation during loading**: Users can now browse with j/k/h/l, PgUp/PgDn, Home/End, g/G, Ctrl+D/U while content loads in the background. Only action keys (Enter, /, v, i) are blocked during loading.
- **Ctrl+key app-level bindings**: Added Ctrl+C (cancel loading / quit), Ctrl+L (clear screen), Ctrl+R (reverse search alias), Ctrl+G (toggle guide), Ctrl+B (stub for background ops).
- **Connection status indicator**: Footer shows ● (connected), ◐ (loading), ○ (disconnected).
- **Updated help popup**: Added "global shortcuts" section documenting all Ctrl+key bindings.

## Type of Change

- [ ] Bug fix
- [x] New feature / UX improvement
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation

## Testing

- `cargo test --test frontend_screens_test` — 14 passed
- `cargo test --test navigation_test` — 10 passed
- `cargo build --release` — successful
- `cargo fmt` — applied
- `cargo check` — clean (no errors)

## Files Changed

| File | Change |
|------|--------|
| `src/ui/loading.rs` | Rewrote to inline status line (braille spinner + progress) |
| `src/ui/footer.rs` | Added loading footer mode, connection indicator |
| `src/ui/mod.rs` | Removed loading overlay call |
| `src/ui/popups.rs` | Added global shortcuts section to help popup |
| `src/handlers/input.rs` | Unblocked navigation during loading, added Ctrl+key handlers |
| `src/main.rs` | Added Ctrl+L clear screen handling |
| `src/app.rs` | Added `needs_clear` and `loading_cancelled` flags |
| `src/state.rs` | Added `loading_cancelled` field |
| `Cargo.toml` | Bumped to v4.3.0 |