### PR TITLE
[codex] Keep American event packages visible in 'merica mode

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -942,7 +942,7 @@ impl XtreamClient {
 
                         if let Some(total) = total_size {
                             let percent = ((downloaded as f64 / total as f64) * 100.0) as usize;
-                            if percent > last_percent && percent % 2 == 0 {
+                            if percent > last_percent && percent.is_multiple_of(2) {
                                 last_percent = percent;
                                 if let Some(ref sender) = tx {
                                     let bytes_mb = downloaded as f64 / 1_048_576.0;
@@ -1029,7 +1029,7 @@ impl XtreamClient {
 
             let unique_streams = tokio::task::spawn_blocking(move || -> Result<Vec<Stream>, anyhow::Error> {
                 if let Some(ref sender) = tx_clone {
-                    let _ = sender.blocking_send(crate::app::AsyncAction::LoadingMessage(format!("Phase 2/3: Deserializing JSON structures out of RAM heap...")));
+                    let _ = sender.blocking_send(crate::app::AsyncAction::LoadingMessage("Phase 2/3: Deserializing JSON structures out of RAM heap...".to_string()));
                 }
 
                 let streams = serde_json::from_slice::<Vec<Stream>>(&bytes)

--- a/src/app.rs
+++ b/src/app.rs
@@ -415,6 +415,12 @@ pub enum SettingsState {
     About,
 }
 
+impl Default for App {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl App {
     pub fn new() -> App {
         let config = AppConfig::load().unwrap_or_default();
@@ -723,10 +729,10 @@ impl App {
                         if !crate::parser::is_american_live(&c.category_name) {
                             return false;
                         }
-                    } else if use_all_english {
-                        if !crate::parser::is_english_live(&c.category_name) {
-                            return false;
-                        }
+                    } else if use_all_english
+                        && !crate::parser::is_english_live(&c.category_name)
+                    {
+                        return false;
                     }
 
                     true
@@ -1929,20 +1935,13 @@ impl App {
 
         match self.current_screen {
             CurrentScreen::Home => {
-                match key.code {
-                    KeyCode::Char('x') => {
-                        // Logic for Series Entry
-                        if !self.config.accounts.is_empty() {
-                            // We can't easily spawn the async task here without the client credential details
-                            // For testing purposes, we might just return a "signal" or set loading state.
-                            // In a real refactor, we would return an Action enum like `Action::FetchSeries(account_index)`
-                            // key-handling logic should primarily update synchronous state.
-                            self.state_loading = true;
-                            // For testing: we can assert that state_loading became true.
-                        }
+                if let KeyCode::Char('x') = key.code {
+                    // Logic for Series Entry
+                    if !self.config.accounts.is_empty() {
+                        // We can't easily spawn the async task here without the client credential details.
+                        // In a real refactor, we would return an Action enum like `Action::FetchSeries(account_index)`.
+                        self.state_loading = true;
                     }
-                    // ... other Home keys
-                    _ => {}
                 }
             }
             CurrentScreen::ContentTypeSelection => match key.code {
@@ -1971,12 +1970,9 @@ impl App {
             },
             CurrentScreen::Categories | CurrentScreen::Streams => {
                 if self.search_mode {
-                    match key.code {
-                        KeyCode::Esc => {
-                            self.search_mode = false;
-                            self.search_state.query.clear();
-                        }
-                        _ => {}
+                    if key.code == KeyCode::Esc {
+                        self.search_mode = false;
+                        self.search_state.query.clear();
                     }
                 } else {
                     match key.code {

--- a/src/app.rs
+++ b/src/app.rs
@@ -729,9 +729,7 @@ impl App {
                         if !crate::parser::is_american_live(&c.category_name) {
                             return false;
                         }
-                    } else if use_all_english
-                        && !crate::parser::is_english_live(&c.category_name)
-                    {
+                    } else if use_all_english && !crate::parser::is_english_live(&c.category_name) {
                         return false;
                     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2011,16 +2011,16 @@ impl App {
                         }
                         KeyCode::Char('g') => {
                             if self.active_pane == Pane::Categories {
-                                self.jump_to_category_bottom();
+                                self.jump_to_category_top();
                             } else {
-                                self.jump_to_bottom();
+                                self.jump_to_top();
                             }
                         }
                         KeyCode::Char('G') => {
                             if self.active_pane == Pane::Categories {
-                                self.jump_to_category_top();
+                                self.jump_to_category_bottom();
                             } else {
-                                self.jump_to_top();
+                                self.jump_to_bottom();
                             }
                         }
                         KeyCode::Char('0') => {
@@ -2111,15 +2111,15 @@ impl App {
                 KeyCode::Char('k') | KeyCode::Up => self.previous_series_category(),
                 KeyCode::Char('g') => {
                     if !self.series_categories.is_empty() {
-                        self.selected_series_category_index = self.series_categories.len() - 1;
-                        self.series_category_list_state
-                            .select(Some(self.series_categories.len() - 1));
+                        self.selected_series_category_index = 0;
+                        self.series_category_list_state.select(Some(0));
                     }
                 }
                 KeyCode::Char('G') => {
                     if !self.series_categories.is_empty() {
-                        self.selected_series_category_index = 0;
-                        self.series_category_list_state.select(Some(0));
+                        self.selected_series_category_index = self.series_categories.len() - 1;
+                        self.series_category_list_state
+                            .select(Some(self.series_categories.len() - 1));
                     }
                 }
                 KeyCode::Char('0') => {
@@ -2129,7 +2129,7 @@ impl App {
                     }
                 }
                 KeyCode::Char('1') => {
-                    if self.series_categories.len() > 0 {
+                    if !self.series_categories.is_empty() {
                         self.selected_series_category_index = 0;
                         self.series_category_list_state.select(Some(0));
                     }
@@ -2196,8 +2196,8 @@ impl App {
                 }
                 KeyCode::Char('j') | KeyCode::Down => self.next_series_stream(),
                 KeyCode::Char('k') | KeyCode::Up => self.previous_series_stream(),
-                KeyCode::Char('g') => self.jump_to_series_bottom(),
-                KeyCode::Char('G') => self.jump_to_series_top(),
+                KeyCode::Char('g') => self.jump_to_series_top(),
+                KeyCode::Char('G') => self.jump_to_series_bottom(),
                 KeyCode::Char('0') => self.jump_to_series_top(),
                 KeyCode::Char('1') => self.jump_to_series_stream(0),
                 KeyCode::Char('2') => self.jump_to_series_stream(1),

--- a/src/bin/add_account.rs
+++ b/src/bin/add_account.rs
@@ -1,21 +1,22 @@
-use matrix_iptv_lib::config::{AppConfig, Account, AccountType, DnsProvider};
 use directories::ProjectDirs;
+use matrix_iptv_lib::config::{Account, AccountType, AppConfig, DnsProvider};
 use std::fs;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let proj_dirs = ProjectDirs::from("com", "vibecoding", "vibe-iptv").ok_or("Could not find project dirs")?;
+    let proj_dirs =
+        ProjectDirs::from("com", "vibecoding", "vibe-iptv").ok_or("Could not find project dirs")?;
     let config_dir = proj_dirs.config_dir();
     let config_path = config_dir.join("config.json");
-    
+
     fs::create_dir_all(config_dir)?;
-    
+
     let mut config = if config_path.exists() {
         let content = fs::read_to_string(&config_path)?;
         serde_json::from_str(&content)?
     } else {
         AppConfig::default()
     };
-    
+
     // Add new account
     let new_account = Account {
         name: "Strong8k2-PC".to_string(),
@@ -32,17 +33,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         hidden_categories: std::collections::HashSet::new(),
         category_sort_order: matrix_iptv_lib::config::CategorySortOrder::Default,
     };
-    
+
     // Remove if exists
     config.accounts.retain(|a| a.name != new_account.name);
     config.accounts.push(new_account);
-    
+
     // Set DNS to system (for best compatibility with 8080 port bypass)
     config.dns_provider = DnsProvider::System;
-    
+
     let json = serde_json::to_string_pretty(&config)?;
     fs::write(&config_path, json)?;
-    
+
     println!("Successfully added account to {:?}", config_path);
     Ok(())
 }

--- a/src/bin/analyze_playlists.rs
+++ b/src/bin/analyze_playlists.rs
@@ -22,7 +22,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for (name, url, user, pass) in accounts {
         println!("Testing: {} ({})", name, url);
 
-        match XtreamClient::new_with_doh(url.to_string(), user.to_string(), pass.to_string(), matrix_iptv_lib::config::DnsProvider::System).await
+        match XtreamClient::new_with_doh(
+            url.to_string(),
+            user.to_string(),
+            pass.to_string(),
+            matrix_iptv_lib::config::DnsProvider::System,
+        )
+        .await
         {
             Ok(client) => {
                 match client.authenticate().await {

--- a/src/bin/analyze_vod.rs
+++ b/src/bin/analyze_vod.rs
@@ -2,21 +2,25 @@ use matrix_iptv_lib::api::XtreamClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let accounts = vec![
-        (
-            "Example Provider",
-            "http://example.com",
-            "username",
-            "password",
-        ),
-    ];
+    let accounts = vec![(
+        "Example Provider",
+        "http://example.com",
+        "username",
+        "password",
+    )];
 
     println!("=== VOD Content Analysis ===\n");
 
     for (name, url, user, pass) in accounts {
         println!("Testing: {} ({})", name, url);
 
-        match XtreamClient::new_with_doh(url.to_string(), user.to_string(), pass.to_string(), matrix_iptv_lib::config::DnsProvider::System).await
+        match XtreamClient::new_with_doh(
+            url.to_string(),
+            user.to_string(),
+            pass.to_string(),
+            matrix_iptv_lib::config::DnsProvider::System,
+        )
+        .await
         {
             Ok(client) => {
                 match client.authenticate().await {

--- a/src/bin/audit_all.rs
+++ b/src/bin/audit_all.rs
@@ -12,11 +12,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    println!("Found {} accounts. Starting audit...\n", config.accounts.len());
+    println!(
+        "Found {} accounts. Starting audit...\n",
+        config.accounts.len()
+    );
 
     for (i, acc) in config.accounts.iter().enumerate() {
-        println!("[{}/{}] Account: {} ({})", i + 1, config.accounts.len(), acc.name, acc.base_url);
-        
+        println!(
+            "[{}/{}] Account: {} ({})",
+            i + 1,
+            config.accounts.len(),
+            acc.name,
+            acc.base_url
+        );
+
         // 1. Connection & Auth
         let start = Instant::now();
         match XtreamClient::new_with_doh(
@@ -24,7 +33,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             acc.username.clone(),
             acc.password.clone(),
             DnsProvider::System,
-        ).await {
+        )
+        .await
+        {
             Ok(client) => {
                 match client.authenticate().await {
                     Ok((true, _, _)) => {
@@ -36,7 +47,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         match client.get_live_categories().await {
                             Ok(cats) => {
                                 let cat_dur = cat_start.elapsed();
-                                println!("  📂 Categories: {} items in {:.2}s", cats.len(), cat_dur.as_secs_f32());
+                                println!(
+                                    "  📂 Categories: {} items in {:.2}s",
+                                    cats.len(),
+                                    cat_dur.as_secs_f32()
+                                );
 
                                 // 3. Full Stream Fetch (Testing Resilience & Speed)
                                 println!("  🔍 Fetching ALL live streams (Testing Resilience)...");
@@ -44,13 +59,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 match client.get_live_streams("ALL", None).await {
                                     Ok(streams) => {
                                         let stream_dur = stream_start.elapsed();
-                                        println!("  ✅ Streams: {} items in {:.2}s", streams.len(), stream_dur.as_secs_f32());
+                                        println!(
+                                            "  ✅ Streams: {} items in {:.2}s",
+                                            streams.len(),
+                                            stream_dur.as_secs_f32()
+                                        );
 
                                         // 4. MSNBC Search
-                                        let msnbc: Vec<_> = streams.iter()
+                                        let msnbc: Vec<_> = streams
+                                            .iter()
                                             .filter(|s| s.name.to_uppercase().contains("MSNBC"))
                                             .collect();
-                                        
+
                                         if !msnbc.is_empty() {
                                             println!("  📍 Found {} MSNBC streams:", msnbc.len());
                                             for s in msnbc.iter().take(3) {

--- a/src/bin/diagnose_url.rs
+++ b/src/bin/diagnose_url.rs
@@ -1,4 +1,4 @@
-use reqwest::{Client, redirect};
+use reqwest::{redirect, Client};
 use std::time::Duration;
 
 #[tokio::main]
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for (name, ua, referer) in scenarios {
         println!("\n--- Testing Scenario: {} ---", name);
-        
+
         let client = Client::builder()
             .timeout(Duration::from_secs(10))
             .redirect(redirect::Policy::none()) // We want to see the 302, not follow it blindly yet
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 for (k, v) in resp.headers() {
                     println!("  {}: {:?}", k, v);
                 }
-                
+
                 if resp.status().is_redirection() {
                     if let Some(loc) = resp.headers().get("location") {
                         if let Ok(loc_str) = loc.to_str() {
@@ -50,11 +50,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 } else if resp.status().is_success() {
                     println!("SUCCESS: Stream reachable directly!");
                 }
-            },
+            }
             Err(e) => println!("Request Failed: {}", e),
         }
     }
-    
+
     Ok(())
 }
 
@@ -81,14 +81,17 @@ async fn verify_host(url: &str) {
     let client = Client::new();
     match client.get(&doh_url).send().await {
         Ok(resp) => {
-                if let Ok(text) = resp.text().await {
-                    if text.contains("\"Status\": 0") {
-                        println!("  [✓] Host ({}) exists (Google DoH).", host);
-                    } else {
-                        println!("  [X] Host ({}) returned error/NXDOMAIN from Google DoH: {}", host, text);
-                    }
+            if let Ok(text) = resp.text().await {
+                if text.contains("\"Status\": 0") {
+                    println!("  [✓] Host ({}) exists (Google DoH).", host);
+                } else {
+                    println!(
+                        "  [X] Host ({}) returned error/NXDOMAIN from Google DoH: {}",
+                        host, text
+                    );
                 }
-        },
+            }
+        }
         Err(_) => println!("  [?] Could not check DoH for host."),
     }
 }

--- a/src/bin/find_config.rs
+++ b/src/bin/find_config.rs
@@ -3,7 +3,10 @@ use directories::ProjectDirs;
 fn main() {
     if let Some(proj_dirs) = ProjectDirs::from("com", "vibecoding", "vibe-iptv") {
         println!("Config dir: {:?}", proj_dirs.config_dir());
-        println!("Config file: {:?}", proj_dirs.config_dir().join("config.json"));
+        println!(
+            "Config file: {:?}",
+            proj_dirs.config_dir().join("config.json")
+        );
     } else {
         println!("Could not determine project paths");
     }

--- a/src/bin/inspect_auth.rs
+++ b/src/bin/inspect_auth.rs
@@ -1,16 +1,25 @@
 use matrix_iptv_lib::config::AppConfig;
-use tokio;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let args: Vec<String> = std::env::args().collect();
-    
+
     let (base_url, username, password, name) = if args.len() >= 4 {
-        (args[1].clone(), args[2].clone(), args[3].clone(), "Manual".to_string())
+        (
+            args[1].clone(),
+            args[2].clone(),
+            args[3].clone(),
+            "Manual".to_string(),
+        )
     } else {
         let config = AppConfig::load()?;
-        if let Some(acc) = config.accounts.get(0) {
-            (acc.base_url.clone(), acc.username.clone(), acc.password.clone(), acc.name.clone())
+        if let Some(acc) = config.accounts.first() {
+            (
+                acc.base_url.clone(),
+                acc.username.clone(),
+                acc.password.clone(),
+                acc.name.clone(),
+            )
         } else {
             return Err(anyhow::anyhow!("No accounts found and no CLI args provided. Usage: inspect_auth <url> <user> <pass>"));
         }
@@ -18,13 +27,9 @@ async fn main() -> Result<(), anyhow::Error> {
 
     println!("📡 Inspecting account: {}", name);
     println!("🔗 URL: {}", base_url);
-    
+
     use matrix_iptv_lib::api::XtreamClient;
-    let client = XtreamClient::new(
-        base_url,
-        username,
-        password
-    );
+    let client = XtreamClient::new(base_url, username, password);
 
     match client.authenticate().await {
         Ok((success, user_info, _server_info)) => {
@@ -36,7 +41,7 @@ async fn main() -> Result<(), anyhow::Error> {
         }
         Err(e) => {
             println!("❌ Authentication Failed!");
-            println!("{}", e); 
+            println!("{}", e);
         }
     }
     Ok(())

--- a/src/bin/inspect_series.rs
+++ b/src/bin/inspect_series.rs
@@ -5,32 +5,33 @@ use matrix_iptv_lib::config::AppConfig;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load()?;
     let account = &config.accounts[0]; // Trex
-    
+
     let client = XtreamClient::new_with_doh(
         account.base_url.clone(),
         account.username.clone(),
         account.password.clone(),
         config.dns_provider,
-    ).await?;
-    
+    )
+    .await?;
+
     client.authenticate().await?;
-    
+
     // Get series categories
     let cats = client.get_series_categories().await?;
     println!("Found {} series categories", cats.len());
-    
+
     if let Some(first_cat) = cats.first() {
         println!("\nCategory: {}", first_cat.category_name);
-        
+
         // Get series in this category
         let series = client.get_series_streams(&first_cat.category_id).await?;
         println!("Found {} series in category", series.len());
-        
+
         if let Some(first_series) = series.first() {
             println!("\nFirst series structure:");
             println!("{:#?}", first_series);
         }
     }
-    
+
     Ok(())
 }

--- a/src/bin/qa_bot.rs
+++ b/src/bin/qa_bot.rs
@@ -1,7 +1,7 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use matrix_iptv_lib::app::{App, CurrentScreen};
-use tokio::runtime::Runtime;
 use std::sync::Arc;
+use tokio::runtime::Runtime;
 
 fn make_key(code: KeyCode) -> KeyEvent {
     KeyEvent {
@@ -136,20 +136,26 @@ async fn run_qa() {
                         // ---------------------------------------------------------
                         // DEEP FEATURE TESTING: Search, Favorites, URL Gen
                         // ---------------------------------------------------------
-                        
+
                         // 1. Search-Navigation Reset Test (Fix Verification)
                         print!("    > Deep Test (Fix: Search Reset on Escape): ");
                         app.current_screen = CurrentScreen::Categories;
                         app.search_mode = true;
                         app.search_state.query = "NBA".to_string();
-                        
+
                         // Simulate Escape (navigates back to Content Selection)
                         app.handle_key_event(make_key(KeyCode::Esc));
-                        
-                        if !app.search_mode && app.search_state.query.is_empty() && app.current_screen == CurrentScreen::ContentTypeSelection {
+
+                        if !app.search_mode
+                            && app.search_state.query.is_empty()
+                            && app.current_screen == CurrentScreen::ContentTypeSelection
+                        {
                             println!("[PASS] Search Reset on Escape Verified");
                         } else {
-                            println!("[FAIL] Search Reset failed! Mode: {}, Query: '{}', Screen: {:?}", app.search_mode, app.search_state.query, app.current_screen);
+                            println!(
+                                "[FAIL] Search Reset failed! Mode: {}, Query: '{}', Screen: {:?}",
+                                app.search_mode, app.search_state.query, app.current_screen
+                            );
                             total_errors += 1;
                         }
 
@@ -158,11 +164,14 @@ async fn run_qa() {
                         app.current_screen = CurrentScreen::ContentTypeSelection;
                         app.search_mode = true;
                         app.search_state.query = "STILL_HERE".to_string();
-                        
+
                         // Simulate selecting Live TV (Key '1')
                         app.handle_key_event(make_key(KeyCode::Char('1')));
-                        
-                        if !app.search_mode && app.search_state.query.is_empty() && app.current_screen == CurrentScreen::Categories {
+
+                        if !app.search_mode
+                            && app.search_state.query.is_empty()
+                            && app.current_screen == CurrentScreen::Categories
+                        {
                             println!("[PASS] Search Reset on Re-entry Verified");
                         } else {
                             println!("[FAIL] Search Reset failed on entry! Mode: {}, Query: '{}', Screen: {:?}", app.search_mode, app.search_state.query, app.current_screen);

--- a/src/bin/qa_features.rs
+++ b/src/bin/qa_features.rs
@@ -35,7 +35,10 @@ fn main() {
             Ok(config) => {
                 let has_timestamps = config.accounts.iter().all(|a| a.last_refreshed.is_some());
                 if has_timestamps && !config.accounts.is_empty() {
-                    println!("✅ PASS ({} accounts with timestamps)", config.accounts.len());
+                    println!(
+                        "✅ PASS ({} accounts with timestamps)",
+                        config.accounts.len()
+                    );
                     passed += 1;
                 } else if config.accounts.is_empty() {
                     println!("⚠️ SKIP (no accounts configured)");
@@ -58,10 +61,10 @@ fn main() {
         let fresh = now - (12 * 3600); // 12 hours ago
         let stale = now - (48 * 3600); // 48 hours ago
         let threshold = 24i64;
-        
+
         let is_fresh_ok = (now - fresh) <= (threshold * 3600);
         let is_stale_ok = (now - stale) > (threshold * 3600);
-        
+
         if is_fresh_ok && is_stale_ok {
             println!("✅ PASS (fresh=12h OK, stale=48h detected)");
             passed += 1;
@@ -98,7 +101,10 @@ fn main() {
     {
         let mut config = AppConfig::default();
         let idx = config.create_group("Sports".to_string(), Some("⚽".to_string()));
-        if idx == 0 && config.favorites.groups.len() == 1 && config.favorites.groups[0].name == "Sports" {
+        if idx == 0
+            && config.favorites.groups.len() == 1
+            && config.favorites.groups[0].name == "Sports"
+        {
             println!("✅ PASS (created at index {})", idx);
             passed += 1;
         } else {
@@ -114,12 +120,15 @@ fn main() {
         config.create_group("News".to_string(), None);
         config.add_to_group(0, "stream_123".to_string());
         config.add_to_group(0, "stream_456".to_string());
-        
+
         if config.favorites.groups[0].stream_ids.len() == 2 {
             println!("✅ PASS (2 streams added)");
             passed += 1;
         } else {
-            println!("❌ FAIL (got {} streams)", config.favorites.groups[0].stream_ids.len());
+            println!(
+                "❌ FAIL (got {} streams)",
+                config.favorites.groups[0].stream_ids.len()
+            );
             failed += 1;
         }
     }
@@ -131,7 +140,7 @@ fn main() {
         config.create_group("Movies".to_string(), None);
         config.add_to_group(0, "stream_123".to_string());
         config.add_to_group(0, "stream_123".to_string()); // Duplicate
-        
+
         if config.favorites.groups[0].stream_ids.len() == 1 {
             println!("✅ PASS (duplicate rejected)");
             passed += 1;
@@ -149,9 +158,10 @@ fn main() {
         config.add_to_group(0, "stream_a".to_string());
         config.add_to_group(0, "stream_b".to_string());
         config.remove_from_group(0, "stream_a");
-        
-        if config.favorites.groups[0].stream_ids.len() == 1 
-           && config.favorites.groups[0].stream_ids[0] == "stream_b" {
+
+        if config.favorites.groups[0].stream_ids.len() == 1
+            && config.favorites.groups[0].stream_ids[0] == "stream_b"
+        {
             println!("✅ PASS");
             passed += 1;
         } else {
@@ -167,7 +177,7 @@ fn main() {
         config.create_group("Group1".to_string(), None);
         config.create_group("Group2".to_string(), None);
         config.delete_group(0);
-        
+
         if config.favorites.groups.len() == 1 && config.favorites.groups[0].name == "Group2" {
             println!("✅ PASS");
             passed += 1;
@@ -183,7 +193,7 @@ fn main() {
         let mut config = AppConfig::default();
         config.create_group("OldName".to_string(), None);
         config.rename_group(0, "NewName".to_string());
-        
+
         if config.favorites.groups[0].name == "NewName" {
             println!("✅ PASS");
             passed += 1;

--- a/src/bin/sys_benchmark.rs
+++ b/src/bin/sys_benchmark.rs
@@ -1,9 +1,9 @@
-use matrix_iptv_lib::api::{Stream, Category};
-use matrix_iptv_lib::preprocessing::{preprocess_streams, preprocess_categories};
-use matrix_iptv_lib::flex_id::FlexId;
+use matrix_iptv_lib::api::{Category, Stream};
 use matrix_iptv_lib::config::ProcessingMode;
-use std::time::Instant;
+use matrix_iptv_lib::flex_id::FlexId;
+use matrix_iptv_lib::preprocessing::{preprocess_categories, preprocess_streams};
 use std::collections::HashSet;
+use std::time::Instant;
 
 #[tokio::main]
 async fn main() {
@@ -14,25 +14,29 @@ async fn main() {
     println!("Generating mock data...");
     let mut streams = Vec::new();
     for i in 0..50000 {
-        let mut s = Stream::default();
-        s.num = Some(FlexId::from_number((i % 1000) as i64));
-        // Use "USA | NFL" to pass both is_american_live and is_sports_content
-        s.name = format!("USA | NFL: Game Title {} (2024) [4K]", i);
-        s.stream_id = FlexId::from_number(i as i64);
-        s.epg_channel_id = Some("NFL.HD".to_string());
-        s.category_id = Some("1".to_string());
-        s.container_extension = Some("mkv".to_string());
-        s.rating = Some(4.5);
-        s.stream_type = "live".to_string(); 
+        // Use "USA | NFL" to pass both is_american_live and is_sports_content.
+        let s = Stream {
+            num: Some(FlexId::from_number((i % 1000) as i64)),
+            name: format!("USA | NFL: Game Title {} (2024) [4K]", i),
+            stream_id: FlexId::from_number(i as i64),
+            epg_channel_id: Some("NFL.HD".to_string()),
+            category_id: Some("1".to_string()),
+            container_extension: Some("mkv".to_string()),
+            rating: Some(4.5),
+            stream_type: "live".to_string(),
+            ..Default::default()
+        };
         streams.push(s);
     }
 
     let mut categories = Vec::new();
     for i in 0..1000 {
-        let mut c = Category::default();
-        c.category_id = i.to_string();
-        c.category_name = format!("VIP | US | Action Movies {}", i);
-        c.parent_id = FlexId::from_number(0);
+        let c = Category {
+            category_id: i.to_string(),
+            category_name: format!("VIP | US | Action Movies {}", i),
+            parent_id: FlexId::from_number(0),
+            ..Default::default()
+        };
         categories.push(c);
     }
 
@@ -43,20 +47,38 @@ async fn main() {
     // 2. Measure Categories Preprocessing (Zero-Latency Projection)
     println!("Running Category Pre-parsing...");
     let start_cat = Instant::now();
-    preprocess_categories(&mut categories, &favorites, &modes, true, false, "BenchmarkAccount");
+    preprocess_categories(
+        &mut categories,
+        &favorites,
+        &modes,
+        true,
+        false,
+        "BenchmarkAccount",
+    );
     let duration_cat = start_cat.elapsed();
     println!("  >> Processed 1,000 categories in: {:?}\n", duration_cat);
 
     // 3. Measure Stream Preprocessing (Multi-Core & Zero-Copy Sort)
     println!("Running Stream Preprocessing (Filter + Cleaning + Zero-Copy Sort)...");
     let start_proc = Instant::now();
-    
+
     // We pass None for tx to skip UI messages in benchmark
     // is_live = true to match mock data
-    preprocess_streams(&mut streams, &favorites, &modes, true, "BenchmarkAccount", None);
-    
+    preprocess_streams(
+        &mut streams,
+        &favorites,
+        &modes,
+        true,
+        "BenchmarkAccount",
+        None,
+    );
+
     let duration_proc = start_proc.elapsed();
-    println!("  >> Processed {} streams (remaining after filter) in: {:?}\n", streams.len(), duration_proc);
+    println!(
+        "  >> Processed {} streams (remaining after filter) in: {:?}\n",
+        streams.len(),
+        duration_proc
+    );
 
     if streams.is_empty() {
         println!("❌ ERROR: All streams filtered out! Check filter logic in preprocessing.rs");
@@ -65,8 +87,11 @@ async fn main() {
 
     println!("Verification Metrics:");
     println!("  - Cleaned Names (Sample): {}", streams[0].clean_name);
-    println!("  - Multi-Core Utilization: Detected {} logical cores", num_cpus_count());
-    
+    println!(
+        "  - Multi-Core Utilization: Detected {} logical cores",
+        num_cpus_count()
+    );
+
     // Benchmark target: < 800ms for 50k streams (including filtering, parallel cleaning, and sorting)
     if duration_proc.as_millis() < 800 {
         println!("✅ PERFORMANCE TARGET MET: Preprocessing sub-800ms at scale.");
@@ -76,5 +101,7 @@ async fn main() {
 }
 
 fn num_cpus_count() -> usize {
-    std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1)
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
 }

--- a/src/bin/test_espn.rs
+++ b/src/bin/test_espn.rs
@@ -1,19 +1,20 @@
-use matrix_iptv_lib::sports::parse_sports_event;
 use matrix_iptv_lib::scores::ScoreService;
+use matrix_iptv_lib::sports::parse_sports_event;
 
 #[tokio::main]
 async fn main() {
     println!("=== ESPN Score Fetch Test ===\n");
-    
+
     let service = ScoreService::new();
     match service.fetch_scores().await {
         Ok(scores) => {
             println!("Fetched {} games from ESPN\n", scores.len());
-            
+
             // Find Lakers game
             for game in &scores {
-                if game.home_team.to_lowercase().contains("lakers") || 
-                   game.away_team.to_lowercase().contains("lakers") {
+                if game.home_team.to_lowercase().contains("lakers")
+                    || game.away_team.to_lowercase().contains("lakers")
+                {
                     println!("=== LAKERS GAME FOUND ===");
                     println!("Home: {} ({})", game.home_team, game.home_score);
                     println!("Away: {} ({})", game.away_team, game.away_score);
@@ -22,32 +23,42 @@ async fn main() {
                     println!();
                 }
             }
-            
+
             // Test matching with stream name
             let test_names = vec![
                 "Los Angeles Lakers vs Portland Trail Blazers",
                 "🏀 Los Angeles Lakers vs Portland Trail Blazers",
             ];
-            
+
             println!("=== MATCHING TEST ===");
             for name in test_names {
                 println!("Input: {}", name);
                 if let Some(event) = parse_sports_event(name) {
-                    let t1 = event.team1.chars()
+                    let t1 = event
+                        .team1
+                        .chars()
                         .skip_while(|c| !c.is_ascii_alphanumeric() && !c.is_ascii_whitespace())
-                        .collect::<String>().trim().to_lowercase();
+                        .collect::<String>()
+                        .trim()
+                        .to_lowercase();
                     let t2 = event.team2.to_lowercase();
                     println!("  Parsed: {} vs {}", t1, t2);
-                    
+
                     let matched = scores.iter().find(|g| {
                         let h = g.home_team.to_lowercase();
                         let a = g.away_team.to_lowercase();
-                        (h.contains(&t1) || a.contains(&t1) || t1.contains(&h) || t1.contains(&a)) &&
-                        (h.contains(&t2) || a.contains(&t2) || t2.contains(&h) || t2.contains(&a))
+                        (h.contains(&t1) || a.contains(&t1) || t1.contains(&h) || t1.contains(&a))
+                            && (h.contains(&t2)
+                                || a.contains(&t2)
+                                || t2.contains(&h)
+                                || t2.contains(&a))
                     });
-                    
+
                     if let Some(m) = matched {
-                        println!("  MATCHED: {} vs {} ({} - {})", m.home_team, m.away_team, m.home_score, m.away_score);
+                        println!(
+                            "  MATCHED: {} vs {} ({} - {})",
+                            m.home_team, m.away_team, m.home_score, m.away_score
+                        );
                     } else {
                         println!("  NO MATCH");
                     }

--- a/src/bin/test_mpv.rs
+++ b/src/bin/test_mpv.rs
@@ -89,12 +89,10 @@ async fn main() -> Result<(), anyhow::Error> {
             println!("STDOUT:\n{}", stdout);
             println!("STDERR:\n{}", stderr);
             return Ok(());
-        } else {
-            if start_time.elapsed().as_secs() % 5 == 0 {
-                print!(".");
-                use std::io::Write;
-                std::io::stdout().flush().unwrap();
-            }
+        } else if start_time.elapsed().as_secs().is_multiple_of(5) {
+            print!(".");
+            use std::io::Write;
+            std::io::stdout().flush().unwrap();
         }
     }
     

--- a/src/bin/test_mpv.rs
+++ b/src/bin/test_mpv.rs
@@ -1,8 +1,7 @@
-use matrix_iptv_lib::config::{AppConfig, PlayerEngine};
 use matrix_iptv_lib::api::XtreamClient;
-use tokio::time::sleep;
-use matrix_iptv_lib::player::Player;
+use matrix_iptv_lib::config::AppConfig;
 use std::time::Duration;
+use tokio::time::sleep;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {

--- a/src/bin/test_mpv.rs
+++ b/src/bin/test_mpv.rs
@@ -8,74 +8,100 @@ async fn main() -> Result<(), anyhow::Error> {
     println!("Loading config...");
     let config = AppConfig::load().unwrap();
     let account = config.accounts.first().expect("No accounts found");
-    
+
     println!("Authenticating with account: {}", account.name);
-    let client = XtreamClient::new(account.base_url.clone(), account.username.clone(), account.password.clone());
+    let client = XtreamClient::new(
+        account.base_url.clone(),
+        account.username.clone(),
+        account.password.clone(),
+    );
     let _ = client.authenticate().await?;
 
     println!("Fetching Live Categories...");
     let categories = client.get_live_categories().await?;
-    let target_cat = categories.iter().find(|c| c.category_name.contains("NBA")).expect("Could not find NBA category");
+    let target_cat = categories
+        .iter()
+        .find(|c| c.category_name.contains("NBA"))
+        .expect("Could not find NBA category");
 
-    println!("Fetching Streams for Category: {} (ID: {})", target_cat.category_name, target_cat.category_id);
-    let streams = client.get_live_streams(&target_cat.category_id, None).await?;
-    
-    let target_stream = streams.iter().find(|s| s.name.contains("NBA") || s.name.contains("Utah") || s.name.contains("Warriors"))
+    println!(
+        "Fetching Streams for Category: {} (ID: {})",
+        target_cat.category_name, target_cat.category_id
+    );
+    let streams = client
+        .get_live_streams(&target_cat.category_id, None)
+        .await?;
+
+    let target_stream = streams
+        .iter()
+        .find(|s| s.name.contains("NBA") || s.name.contains("Utah") || s.name.contains("Warriors"))
         .or_else(|| streams.first())
-        .expect("Could not find any stream in this category").clone();
+        .expect("Could not find any stream in this category")
+        .clone();
 
     let stream_id = target_stream.stream_id.to_string();
-    
+
     let url = client.get_stream_url(&stream_id, "ts");
-    println!("\nFound Stream!\nTitle: {}\nURL: [HIDDEN FOR OUTPUT SECURITY]\n", target_stream.name);
+    println!(
+        "\nFound Stream!\nTitle: {}\nURL: [HIDDEN FOR OUTPUT SECURITY]\n",
+        target_stream.name
+    );
 
     println!("Launching MPV...");
-    
+
     // Find mpv executable
     let mpv_path = matrix_iptv_lib::setup::get_mpv_path().expect("Could not find mpv");
-    
+
     // Start mpv
     let mut cmd = std::process::Command::new(mpv_path);
     cmd.arg(&url);
     cmd.arg("--force-window=immediate");
     cmd.arg("--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
-    
+
     // Add referrer matching the base url (very common IPTV requirement)
     if let Ok(parsed_url) = reqwest::Url::parse(&url) {
-         let origin = format!("{}://{}", parsed_url.scheme(), parsed_url.host_str().unwrap_or(""));
-         cmd.arg(format!("--referrer={}/", origin));
+        let origin = format!(
+            "{}://{}",
+            parsed_url.scheme(),
+            parsed_url.host_str().unwrap_or("")
+        );
+        cmd.arg(format!("--referrer={}/", origin));
     } else {
-         cmd.arg(format!("--referrer={}", url));
+        cmd.arg(format!("--referrer={}", url));
     }
 
     // v4.0.17: 'Anti-Loop' Profile
-    cmd.arg("--demuxer-max-bytes=64MiB");    
+    cmd.arg("--demuxer-max-bytes=64MiB");
     cmd.arg("--demuxer-max-back-bytes=0");
-    cmd.arg("--demuxer-readahead-secs=15");   
+    cmd.arg("--demuxer-readahead-secs=15");
     cmd.arg("--demuxer-thread=yes");
     cmd.arg("--stream-buffer-size=512KiB");
     cmd.arg("--network-timeout=60");
-    cmd.arg("--cache-pause=no"); 
-    cmd.arg("--keep-open=yes"); 
+    cmd.arg("--cache-pause=no");
+    cmd.arg("--keep-open=yes");
     cmd.arg("--stream-lavf-o=reconnect=1,reconnect_at_eof=1,reconnect_streamed=1,reconnect_delay_max=5,multiple_requests=1");
     cmd.arg("--demuxer-lavf-o=analyzeduration=3000000,probesize=3000000,fflags=+genpts+igndts");
     cmd.arg("--tls-verify=no");
     cmd.arg("--ytdl=no");
     cmd.arg("--msg-level=all=v");
     cmd.arg("--log-file=mpv_trace.log");
-    
+
     cmd.stdout(std::process::Stdio::piped())
-       .stderr(std::process::Stdio::piped());
-       
+        .stderr(std::process::Stdio::piped());
+
     let mut child = cmd.spawn()?;
-    
+
     println!("Testing stability... waiting 130 seconds...");
     let start_time = std::time::Instant::now();
-    
+
     while start_time.elapsed().as_secs() < 130 {
         sleep(Duration::from_secs(1)).await;
         if let Ok(Some(status)) = child.try_wait() {
-            println!("\n[FAILURE] Player died after {} seconds! Status: {}", start_time.elapsed().as_secs(), status);
+            println!(
+                "\n[FAILURE] Player died after {} seconds! Status: {}",
+                start_time.elapsed().as_secs(),
+                status
+            );
             let mut stdout = String::new();
             let mut stderr = String::new();
             if let Some(mut out) = child.stdout.take() {
@@ -95,7 +121,7 @@ async fn main() -> Result<(), anyhow::Error> {
             std::io::stdout().flush().unwrap();
         }
     }
-    
+
     println!("\n[SUCCESS] Player is still running after >2 mins of playback!");
     let _ = child.kill();
     Ok(())

--- a/src/bin/test_series_info.rs
+++ b/src/bin/test_series_info.rs
@@ -5,50 +5,51 @@ use matrix_iptv_lib::config::AppConfig;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = AppConfig::load()?;
     let account = &config.accounts[0]; // Trex
-    
+
     let client = XtreamClient::new_with_doh(
         account.base_url.clone(),
         account.username.clone(),
         account.password.clone(),
         config.dns_provider,
-    ).await?;
-    
+    )
+    .await?;
+
     client.authenticate().await?;
-    
+
     // Get series categories
     let cats = client.get_series_categories().await?;
-    
+
     // Find a category with series
     if let Some(cat) = cats.iter().find(|c| c.category_name.contains("APPLE")) {
         println!("Category: {}", cat.category_name);
-        
+
         // Get series in this category
         let series = client.get_series_streams(&cat.category_id).await?;
         println!("Found {} series", series.len());
-        
+
         // Use first series
         if let Some(show) = series.first() {
             println!("\nTesting with Series: {}", show.name);
             println!("Stream ID: {:?}", show.stream_id);
-            
+
             // Get series ID from stream_id
             let series_id = show.stream_id.to_string_value().unwrap_or_default();
-            
+
             println!("\nFetching series info for ID: {}", series_id);
-            
+
             // Make direct API call to get_series_info
             let url = format!(
                 "{}/player_api.php?username={}&password={}&action=get_series_info&series_id={}",
                 account.base_url, account.username, account.password, series_id
             );
-            
+
             println!("URL: {}", url);
-            
+
             let response: serde_json::Value = reqwest::get(&url).await?.json().await?;
             println!("\nSeries Info Response:");
             println!("{:#?}", response);
         }
     }
-    
+
     Ok(())
 }

--- a/src/bin/test_strong.rs
+++ b/src/bin/test_strong.rs
@@ -4,26 +4,29 @@ use matrix_iptv_lib::config::AppConfig;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Testing Strong8K Playlist ===\n");
-    
+
     let config = AppConfig::load()?;
-    
+
     // Find Strong8K account
-    let strong_account = config.accounts.iter()
+    let strong_account = config
+        .accounts
+        .iter()
         .find(|a| a.name.to_lowercase().contains("strong"))
         .expect("Strong8K account not found");
-    
+
     println!("Account: {}", strong_account.name);
     println!("URL: {}", strong_account.base_url);
     println!();
-    
+
     // Create client
     let client = XtreamClient::new_with_doh(
         strong_account.base_url.clone(),
         strong_account.username.clone(),
         strong_account.password.clone(),
         config.dns_provider,
-    ).await?;
-    
+    )
+    .await?;
+
     // Test authentication
     print!("Testing authentication... ");
     match client.authenticate().await {
@@ -37,30 +40,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             return Ok(());
         }
     }
-    
+
     // Test Live TV
     print!("Testing Live TV categories... ");
     match client.get_live_categories().await {
         Ok(cats) => println!("✓ PASS - {} categories", cats.len()),
         Err(e) => println!("✗ FAIL - {}", e),
     }
-    
+
     // Test VOD/Movies
     print!("Testing VOD/Movies categories... ");
     match client.get_vod_categories().await {
         Ok(cats) => println!("✓ PASS - {} categories", cats.len()),
         Err(e) => println!("✗ FAIL - {}", e),
     }
-    
+
     // Test Series
     print!("Testing Series categories... ");
     match client.get_series_categories().await {
         Ok(cats) => {
             println!("✓ PASS - {} categories", cats.len());
-            
+
             // Test loading streams from first category
             if let Some(first_cat) = cats.first() {
-                print!("  Testing streams in '{}' category... ", first_cat.category_name);
+                print!(
+                    "  Testing streams in '{}' category... ",
+                    first_cat.category_name
+                );
                 match client.get_series_streams(&first_cat.category_id).await {
                     Ok(streams) => println!("✓ PASS - {} series", streams.len()),
                     Err(e) => println!("✗ FAIL - {}", e),
@@ -69,7 +75,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Err(e) => println!("✗ FAIL - {}", e),
     }
-    
+
     println!("\n=== Strong8K Test Complete ===");
     Ok(())
 }

--- a/src/bin/test_user_playlist.rs
+++ b/src/bin/test_user_playlist.rs
@@ -4,19 +4,19 @@ use matrix_iptv_lib::config::DnsProvider;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Testing User Playlist with 8080 Approach ===\n");
-    
+
     let base_url = "http://zfruvync.rmtil.com:8080".to_string();
     let username = "PE1S9S8U".to_string();
     let password = "11EZZUMW".to_string();
-    
+
     println!("URL: {}", base_url);
     println!("User: {}", username);
     println!();
-    
+
     // Create client with System DNS first (to see if it hits the AT&T block)
     println!("--- Testing with System DNS ---");
     let client = XtreamClient::new(base_url.clone(), username.clone(), password.clone());
-    
+
     match client.authenticate().await {
         Ok((success, ui, _)) => {
             if success {
@@ -36,26 +36,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("\n--- Testing with Quad9 DoH (Bypasses local DNS blocks) ---");
     match XtreamClient::new_with_doh(base_url, username, password, DnsProvider::Quad9).await {
-        Ok(client) => {
-             match client.authenticate().await {
-                Ok((success, ui, _)) => {
-                    if success {
-                        println!("✓ PASS - Authenticated successfully via Quad9!");
-                        if let Some(info) = ui {
-                            println!("Status: {:?}", info.status);
-                        }
-                    } else {
-                        println!("✗ FAIL - Authentication failed via Quad9");
+        Ok(client) => match client.authenticate().await {
+            Ok((success, ui, _)) => {
+                if success {
+                    println!("✓ PASS - Authenticated successfully via Quad9!");
+                    if let Some(info) = ui {
+                        println!("Status: {:?}", info.status);
                     }
-                }
-                Err(e) => {
-                    println!("✗ FAIL - Error via Quad9: {}", e);
+                } else {
+                    println!("✗ FAIL - Authentication failed via Quad9");
                 }
             }
-        }
+            Err(e) => {
+                println!("✗ FAIL - Error via Quad9: {}", e);
+            }
+        },
         Err(e) => println!("✗ FAIL - Could not initialize DoH client: {}", e),
     }
-    
+
     println!("\n=== Test Complete ===");
     Ok(())
 }

--- a/src/bin/verify_msnbc.rs
+++ b/src/bin/verify_msnbc.rs
@@ -4,24 +4,28 @@ use matrix_iptv_lib::config::AppConfig;
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let config = AppConfig::load()?;
-    let acc = config.accounts.get(0).ok_or_else(|| anyhow::anyhow!("No active account found"))?;
-    
+    let acc = config
+        .accounts
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("No active account found"))?;
+
     println!("📡 Fetching Live Channels for account: {}", acc.name);
     println!("🔗 URL: {}", acc.base_url);
-    
+
     let base_url_8080 = format!("{}:8080", acc.base_url);
     println!("🔗 Testing Stream on URL: {}", base_url_8080);
-    
+
     let client = XtreamClient::new(
         base_url_8080.clone(),
         acc.username.clone(),
-        acc.password.clone()
+        acc.password.clone(),
     );
 
     let streams = client.get_live_streams("0", None).await?;
     println!("✅ Fetched {} streams total", streams.len());
 
-    let msnbc_streams: Vec<_> = streams.iter()
+    let msnbc_streams: Vec<_> = streams
+        .iter()
         .filter(|s| s.name.to_lowercase().contains("msnbc"))
         .collect();
 
@@ -37,61 +41,68 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Try to verify the first one
     let target = msnbc_streams[0];
-    let stream_url = format!("{}/live/{}/{}/{}.ts", base_url_8080, acc.username, acc.password, target.stream_id);
-    
+    let stream_url = format!(
+        "{}/live/{}/{}/{}.ts",
+        base_url_8080, acc.username, acc.password, target.stream_id
+    );
+
     let client_http = reqwest::Client::builder()
         .user_agent("IPTVSmartersPlayer")
         .build()?;
-    
+
     println!("🔗 Verifying stream URL: {}", stream_url);
-    
+
     let mut resp = client_http.get(&stream_url).send().await;
-    
+
     // Resilience: Fallback to DoH if DNS fails for the stream as well
     if let Err(ref e) = resp {
         let err_str = e.to_string().to_lowercase();
         println!("DEBUG: Stream request error: {}", err_str);
-        
-        if err_str.contains("dns") || 
-           err_str.contains("resolution") || 
-           err_str.contains("resolve") || 
-           err_str.contains("no such host") ||
-           err_str.contains("11004") ||
-           err_str.contains("no data") 
+
+        if err_str.contains("dns")
+            || err_str.contains("resolution")
+            || err_str.contains("resolve")
+            || err_str.contains("no such host")
+            || err_str.contains("11004")
+            || err_str.contains("no data")
         {
-             println!("⚠️ DNS Error on stream! Trying DoH fallback...");
-             // Manual DoH resolve for the stream host
-             // Using Quad9 IP-based DoH to avoid resolving the DoH host itself
-             let doh_url = "https://9.9.9.9/dns-query?name=zfruvync.duperab.xyz";
-             println!("🔗 Resolving via DoH: {}", doh_url);
-             let doh_resp = client_http.get(doh_url)
-                 .header("Accept", "application/dns-json")
-                 .send().await?;
-             let doh_json: serde_json::Value = doh_resp.json().await?;
-             
-             if let Some(answers) = doh_json.get("Answer").and_then(|a| a.as_array()) {
-                 if let Some(ip) = answers[0].get("data").and_then(|d| d.as_str()) {
-                     println!("✅ DoH Resolved stream host to: {}", ip);
-                     let resolved_url = stream_url.replace("zfruvync.duperab.xyz", ip);
-                     println!("🔗 Using resolved stream URL: {}", resolved_url);
-                     resp = client_http.get(&resolved_url)
-                         .header("Host", "zfruvync.duperab.xyz")
-                         .send().await;
-                 }
-             }
+            println!("⚠️ DNS Error on stream! Trying DoH fallback...");
+            // Manual DoH resolve for the stream host
+            // Using Quad9 IP-based DoH to avoid resolving the DoH host itself
+            let doh_url = "https://9.9.9.9/dns-query?name=zfruvync.duperab.xyz";
+            println!("🔗 Resolving via DoH: {}", doh_url);
+            let doh_resp = client_http
+                .get(doh_url)
+                .header("Accept", "application/dns-json")
+                .send()
+                .await?;
+            let doh_json: serde_json::Value = doh_resp.json().await?;
+
+            if let Some(answers) = doh_json.get("Answer").and_then(|a| a.as_array()) {
+                if let Some(ip) = answers[0].get("data").and_then(|d| d.as_str()) {
+                    println!("✅ DoH Resolved stream host to: {}", ip);
+                    let resolved_url = stream_url.replace("zfruvync.duperab.xyz", ip);
+                    println!("🔗 Using resolved stream URL: {}", resolved_url);
+                    resp = client_http
+                        .get(&resolved_url)
+                        .header("Host", "zfruvync.duperab.xyz")
+                        .send()
+                        .await;
+                }
+            }
         }
     }
 
     let resp = resp?;
-    
+
     if resp.status().is_success() {
         println!("✅ Stream URL is reachable (Status: {})", resp.status());
         let bytes = resp.bytes().await?;
         println!("📦 Stream content size: {} bytes", bytes.len());
-        if bytes.len() > 0 {
-             println!("🚀 Playback verified: Stream is providing data!");
+        if !bytes.is_empty() {
+            println!("🚀 Playback verified: Stream is providing data!");
         } else {
-             println!("⚠️ Stream is reachable but returned 0 bytes.");
+            println!("⚠️ Stream is reachable but returned 0 bytes.");
         }
     } else {
         println!("❌ Stream URL failed (Status: {})", resp.status());

--- a/src/bin/verify_ui.rs
+++ b/src/bin/verify_ui.rs
@@ -1,6 +1,6 @@
 use matrix_iptv_lib::parser::parse_stream;
-use matrix_iptv_lib::ui::common::stylize_channel_name;
 use matrix_iptv_lib::ui::colors::MATRIX_GREEN;
+use matrix_iptv_lib::ui::common::stylize_channel_name;
 use ratatui::style::Color;
 
 fn main() {
@@ -38,12 +38,21 @@ fn main() {
             print!("[\"{}\" : {}] ", span.content, color);
         }
         println!("\n");
-        
+
         // Assertions for "Before Sunrise (1995)"
         if name.contains("Before Sunrise") {
-            assert!(!parsed.display_name.contains("EN"), "Should strip EN prefix");
-            assert!(parsed.display_name.contains("Before Sunrise"), "Should contain title");
-            assert!(parsed.display_name.contains("(1995)"), "Should preserve year");
+            assert!(
+                !parsed.display_name.contains("EN"),
+                "Should strip EN prefix"
+            );
+            assert!(
+                parsed.display_name.contains("Before Sunrise"),
+                "Should contain title"
+            );
+            assert!(
+                parsed.display_name.contains("(1995)"),
+                "Should preserve year"
+            );
         }
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -16,9 +16,9 @@ const CACHE_VERSION: u32 = 1;
 #[derive(Serialize, Deserialize)]
 pub struct CachedCatalog {
     pub version: u32,
-    pub cached_at: u64,            // Unix timestamp (seconds)
+    pub cached_at: u64, // Unix timestamp (seconds)
     pub account_name: String,
-    pub account_url: String,       // To detect if provider changed
+    pub account_url: String, // To detect if provider changed
 
     // Pre-preprocessed data (already filtered by active modes at cache time)
     pub processing_modes: Vec<ProcessingMode>,

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,5 +1,5 @@
 //! Chromecast casting support for Matrix IPTV
-//! 
+//!
 //! This module provides functionality for discovering and streaming to Chromecast devices.
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -12,11 +12,11 @@ use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 use mdns_sd::{ServiceDaemon, ServiceEvent};
 #[cfg(not(target_arch = "wasm32"))]
-use rust_cast::{CastDevice as RustCastDevice, ChannelMessage};
-#[cfg(not(target_arch = "wasm32"))]
 use rust_cast::channels::media::{Media, StreamType};
 #[cfg(not(target_arch = "wasm32"))]
 use rust_cast::channels::receiver::CastDeviceApp;
+#[cfg(not(target_arch = "wasm32"))]
+use rust_cast::{CastDevice as RustCastDevice, ChannelMessage};
 
 /// Represents a discovered Chromecast device
 #[derive(Debug, Clone)]
@@ -85,36 +85,36 @@ impl CastManager {
     }
 
     /// Discover Chromecast devices on the local network
-    /// 
+    ///
     /// Scans for the specified duration and returns all found devices.
     pub async fn discover_devices(timeout_secs: u64) -> Result<Vec<CastDevice>, anyhow::Error> {
         use tokio::time::sleep;
-        
+
         let mdns = ServiceDaemon::new()
             .map_err(|e| anyhow::anyhow!("Failed to create mDNS daemon: {}", e))?;
-        
+
         // Chromecast uses _googlecast._tcp.local.
         let receiver = mdns
             .browse("_googlecast._tcp.local.")
             .map_err(|e| anyhow::anyhow!("Failed to browse for Chromecast devices: {}", e))?;
-        
+
         let mut devices = Vec::new();
         let timeout = Duration::from_secs(timeout_secs);
         let start = std::time::Instant::now();
-        
+
         // Collect devices for the timeout duration
         while start.elapsed() < timeout {
             match receiver.try_recv() {
                 Ok(event) => {
                     if let ServiceEvent::ServiceResolved(info) = event {
                         // Extract device info
-                        let name = info.get_property_val_str("fn")
+                        let name = info
+                            .get_property_val_str("fn")
                             .unwrap_or_else(|| info.get_fullname())
                             .to_string();
-                        
-                        let model = info.get_property_val_str("md")
-                            .map(|s| s.to_string());
-                        
+
+                        let model = info.get_property_val_str("md").map(|s| s.to_string());
+
                         // Get IP addresses
                         for addr in info.get_addresses() {
                             if let IpAddr::V4(ipv4) = addr {
@@ -124,7 +124,7 @@ impl CastManager {
                                     info.get_port(),
                                 );
                                 device.model = model.clone();
-                                
+
                                 // Avoid duplicates
                                 if !devices.iter().any(|d: &CastDevice| d.ip == device.ip) {
                                     devices.push(device);
@@ -139,34 +139,45 @@ impl CastManager {
                 }
             }
         }
-        
+
         // Stop browsing
         let _ = mdns.stop_browse("_googlecast._tcp.local.");
         let _ = mdns.shutdown();
-        
+
         Ok(devices)
     }
 
     /// Cast a media URL to a Chromecast device
-    pub fn cast_to_device(&mut self, device: &CastDevice, url: &str, title: Option<&str>) -> Result<(), anyhow::Error> {
+    pub fn cast_to_device(
+        &mut self,
+        device: &CastDevice,
+        url: &str,
+        title: Option<&str>,
+    ) -> Result<(), anyhow::Error> {
         // Connect to the Chromecast
-        let cast_device = RustCastDevice::connect_without_host_verification(
-            &device.ip, 
-            device.port
-        ).map_err(|e| anyhow::anyhow!("Failed to connect to Chromecast '{}': {}", device.name, e))?;
-        
+        let cast_device =
+            RustCastDevice::connect_without_host_verification(&device.ip, device.port).map_err(
+                |e| anyhow::anyhow!("Failed to connect to Chromecast '{}': {}", device.name, e),
+            )?;
+
         // Connect to receiver
-        cast_device.connection.connect("receiver-0")
+        cast_device
+            .connection
+            .connect("receiver-0")
             .map_err(|e| anyhow::anyhow!("Failed to connect to receiver: {}", e))?;
-        
+
         // Launch the default media receiver app
-        let app = cast_device.receiver.launch_app(&CastDeviceApp::DefaultMediaReceiver)
+        let app = cast_device
+            .receiver
+            .launch_app(&CastDeviceApp::DefaultMediaReceiver)
             .map_err(|e| anyhow::anyhow!("Failed to launch media receiver: {}", e))?;
-        
+
         // Connect to the media receiver
-        cast_device.connection.connect(&app.transport_id)
+        cast_device
+            .connection
+            .connect(&app.transport_id)
             .map_err(|e| anyhow::anyhow!("Failed to connect to media receiver: {}", e))?;
-        
+
         // Create media info
         let media = Media {
             content_id: url.to_string(),
@@ -175,19 +186,18 @@ impl CastManager {
             duration: None,
             metadata: None,
         };
-        
+
         // Load and play the media
-        cast_device.media.load(
-            &app.transport_id,
-            &app.session_id,
-            &media,
-        ).map_err(|e| anyhow::anyhow!("Failed to load media: {}", e))?;
-        
+        cast_device
+            .media
+            .load(&app.transport_id, &app.session_id, &media)
+            .map_err(|e| anyhow::anyhow!("Failed to load media: {}", e))?;
+
         // Store the active connection info
         self.connection = Some(ActiveCast {
             device: device.clone(),
         });
-        
+
         Ok(())
     }
 
@@ -197,7 +207,7 @@ impl CastManager {
             // Reconnect to stop
             if let Ok(cast_device) = RustCastDevice::connect_without_host_verification(
                 &active.device.ip,
-                active.device.port
+                active.device.port,
             ) {
                 let _ = cast_device.connection.connect("receiver-0");
                 let _ = cast_device.receiver.stop_app("receiver-0");
@@ -233,23 +243,28 @@ impl CastManager {
     pub fn new() -> Self {
         Self
     }
-    
+
     pub async fn discover_devices(_timeout_secs: u64) -> Result<Vec<CastDevice>, anyhow::Error> {
         Err(anyhow::anyhow!("Casting not supported in browser"))
     }
-    
-    pub fn cast_to_device(&mut self, _device: &CastDevice, _url: &str, _title: Option<&str>) -> Result<(), anyhow::Error> {
+
+    pub fn cast_to_device(
+        &mut self,
+        _device: &CastDevice,
+        _url: &str,
+        _title: Option<&str>,
+    ) -> Result<(), anyhow::Error> {
         Err(anyhow::anyhow!("Casting not supported in browser"))
     }
-    
+
     pub fn stop_cast(&mut self) -> Result<(), anyhow::Error> {
         Ok(())
     }
-    
+
     pub fn is_casting(&self) -> bool {
         false
     }
-    
+
     pub fn current_device(&self) -> Option<&CastDevice> {
         None
     }
@@ -271,7 +286,7 @@ mod tests {
         let d1 = CastDevice::new("TV 1".into(), "192.168.1.100".into(), 8009);
         let d2 = CastDevice::new("TV 1".into(), "192.168.1.100".into(), 8009);
         let d3 = CastDevice::new("TV 2".into(), "192.168.1.101".into(), 8009);
-        
+
         assert_eq!(d1, d2);
         assert_ne!(d1, d3);
     }

--- a/src/doh.rs
+++ b/src/doh.rs
@@ -1,17 +1,14 @@
-/// DNS-over-HTTPS fallback utility.
-///
-/// Extracts the hostname from a URL, queries multiple DoH providers for an A record,
-/// and attempts to reconnect using the resolved IP. Only works for plain HTTP — HTTPS
-/// will fail due to TLS SNI mismatch so we skip the retry in that case.
+//! DNS-over-HTTPS fallback utility.
+//!
+//! Extracts the hostname from a URL, queries multiple DoH providers for an A record,
+//! and attempts to reconnect using the resolved IP. Only works for plain HTTP — HTTPS
+//! will fail due to TLS SNI mismatch so we skip the retry in that case.
 
 /// Attempt to resolve DNS via DoH and retry the request.
 /// Returns `Some(Response)` if a DoH provider resolves and the retry succeeds.
 /// Returns `None` if DNS resolution fails, URL is HTTPS, or the retry fails.
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn try_doh_fallback(
-    client: &reqwest::Client,
-    url: &str,
-) -> Option<reqwest::Response> {
+pub async fn try_doh_fallback(client: &reqwest::Client, url: &str) -> Option<reqwest::Response> {
     // Only attempt IP substitution for plain HTTP endpoints.
     // HTTPS requires TLS SNI to match the hostname — substituting an IP will
     // cause a certificate mismatch and the handshake will always fail.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -68,35 +68,35 @@ pub enum IptvError {
     /// DNS resolution failed
     #[error("📡 DNS Resolve Error: Could not find server host '{0}'.\nDetail: {1}\nSuggestion: Try enabling 'Quad9 DoH' in Settings.")]
     DnsResolution(String, String),
- 
+
     /// Connection timeout
     #[error("⏱️ Connection Timeout (after {1}s) to server: {0}.\nSuggestion: Higher provider latency or server offline.")]
     ConnectionTimeout(String, u64),
- 
+
     /// Connection failed
     #[error("🚫 {0} Failure: {1}\nSuggestion: {}", .0.suggestion())]
     ConnectionFailed(ConnectionStage, String),
- 
+
     /// Authentication failed
     #[error("🔑 Authentication Denied: {0}\nSuggestion: Double check username/password with your provider.")]
     AuthenticationFailed(String),
- 
+
     /// Server returned an error status
     #[error("⚠️ Server Error ({0}): {1}\nSuggestion: Provider may be experiencing issues.")]
     ServerError(u16, String),
- 
+
     /// Failed to parse response
     #[error("📦 Data Format Error: {0}\nSuggestion: Provider sent corrupted or unexpected data.")]
     ParseError(String),
- 
+
     /// Empty or invalid response
     #[error("🕳️ Empty response from server: {0}")]
     EmptyResponse(String),
- 
+
     /// ISP block detected
     #[error("🛡️ ISP BLOCK DETECTED!\nYour internet provider is actively blocking this IPTV server.\n🔧 FIX: Disable 'Secure Home' features in your router or use a VPN.")]
     IspBlock,
- 
+
     /// Generic error
     #[error("Error: {0}")]
     Generic(String),
@@ -116,22 +116,40 @@ impl IptvError {
                 format!("Connection Timeout\nHost: {}\nTimeout: {} seconds\nSuggestion: Server is slow or offline", host, timeout)
             }
             IptvError::ConnectionFailed(stage, source) => {
-                format!("Connection Failed at {}\nError: {}\nSuggestion: {}", stage.display_name(), source, stage.suggestion())
+                format!(
+                    "Connection Failed at {}\nError: {}\nSuggestion: {}",
+                    stage.display_name(),
+                    source,
+                    stage.suggestion()
+                )
             }
             IptvError::AuthenticationFailed(reason) => {
-                format!("Authentication Failed\nReason: {}\nSuggestion: Verify username and password", reason)
+                format!(
+                    "Authentication Failed\nReason: {}\nSuggestion: Verify username and password",
+                    reason
+                )
             }
             IptvError::ServerError(status, message) => {
-                format!("Server Error\nStatus: {}\nMessage: {}\nSuggestion: Try again later", status, message)
+                format!(
+                    "Server Error\nStatus: {}\nMessage: {}\nSuggestion: Try again later",
+                    status, message
+                )
             }
             IptvError::ParseError(source) => {
-                format!("Parse Error\nError: {}\nSuggestion: Provider response is invalid", source)
+                format!(
+                    "Parse Error\nError: {}\nSuggestion: Provider response is invalid",
+                    source
+                )
             }
             IptvError::EmptyResponse(reason) => {
-                format!("Empty Response\nReason: {}\nSuggestion: Try again later", reason)
+                format!(
+                    "Empty Response\nReason: {}\nSuggestion: Try again later",
+                    reason
+                )
             }
             IptvError::IspBlock => {
-                format!("ISP Block Detected\nSuggestion: Disable AT&T Home Network Security or use a VPN")
+                "ISP Block Detected\nSuggestion: Disable AT&T Home Network Security or use a VPN"
+                    .to_string()
             }
             IptvError::Generic(message) => {
                 format!("Error\nMessage: {}\nSuggestion: Try again", message)
@@ -166,7 +184,11 @@ impl LoadingProgress {
 
     pub fn to_message(&self) -> String {
         let progress = format!("[{}/{}]", self.current, self.total);
-        let eta = self.eta.as_ref().map(|d| format!(" ETA: {}s", d.as_secs())).unwrap_or_default();
+        let eta = self
+            .eta
+            .as_ref()
+            .map(|d| format!(" ETA: {}s", d.as_secs()))
+            .unwrap_or_default();
         format!("{} - {} {}", self.stage.display_name(), progress, eta)
     }
 }

--- a/src/flex_id.rs
+++ b/src/flex_id.rs
@@ -3,17 +3,12 @@ use std::fmt;
 
 /// A flexible ID type that can deserialize from number, string, or null
 /// This handles inconsistent API responses from IPTV providers
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub enum FlexId {
     Number(i64),
     String(String),
+    #[default]
     Null,
-}
-
-impl Default for FlexId {
-    fn default() -> Self {
-        FlexId::Null
-    }
 }
 
 impl FlexId {
@@ -21,12 +16,12 @@ impl FlexId {
     pub fn from_number(n: i64) -> Self {
         FlexId::Number(n)
     }
-    
+
     /// Create a FlexId from a string
     pub fn from_string(s: String) -> Self {
         FlexId::String(s)
     }
-    
+
     /// Get as i64 if this is a number
     pub fn as_i64(&self) -> Option<i64> {
         match self {
@@ -35,7 +30,7 @@ impl FlexId {
             FlexId::Null => None,
         }
     }
-    
+
     /// Get as &str if this is a string
     pub fn as_str(&self) -> Option<&str> {
         match self {
@@ -44,7 +39,7 @@ impl FlexId {
             FlexId::Null => None,
         }
     }
-    
+
     /// Get as string (converts numbers to string)
     pub fn to_string_value(&self) -> Option<String> {
         match self {
@@ -53,12 +48,12 @@ impl FlexId {
             FlexId::Null => None,
         }
     }
-    
+
     /// Check if this is null
     pub fn is_null(&self) -> bool {
         matches!(self, FlexId::Null)
     }
-    
+
     /// Check if this has a value
     pub fn is_some(&self) -> bool {
         !self.is_null()
@@ -94,16 +89,16 @@ impl<'de> Deserialize<'de> for FlexId {
         D: Deserializer<'de>,
     {
         use serde::de::{self, Visitor};
-        
+
         struct FlexIdVisitor;
-        
+
         impl<'de> Visitor<'de> for FlexIdVisitor {
             type Value = FlexId;
-            
+
             fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.write_str("a number, string, or null")
             }
-            
+
             fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
             where
                 E: de::Error,
@@ -123,14 +118,14 @@ impl<'de> Deserialize<'de> for FlexId {
                     Ok(FlexId::String(v.to_string()))
                 }
             }
-            
+
             fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
             where
                 E: de::Error,
             {
                 Ok(FlexId::Number(v as i64))
             }
-            
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
             where
                 E: de::Error,
@@ -142,7 +137,7 @@ impl<'de> Deserialize<'de> for FlexId {
                     Ok(FlexId::String(v.to_string()))
                 }
             }
-            
+
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
             where
                 E: de::Error,
@@ -153,14 +148,14 @@ impl<'de> Deserialize<'de> for FlexId {
                     Ok(FlexId::String(v))
                 }
             }
-            
+
             fn visit_none<E>(self) -> Result<Self::Value, E>
             where
                 E: de::Error,
             {
                 Ok(FlexId::Null)
             }
-            
+
             fn visit_unit<E>(self) -> Result<Self::Value, E>
             where
                 E: de::Error,
@@ -168,7 +163,7 @@ impl<'de> Deserialize<'de> for FlexId {
                 Ok(FlexId::Null)
             }
         }
-        
+
         deserializer.deserialize_any(FlexIdVisitor)
     }
 }
@@ -188,7 +183,7 @@ where
     D: Deserializer<'de>,
 {
     use serde::de::Error;
-    
+
     let flex = FlexId::deserialize(deserializer)?;
     match flex {
         FlexId::Number(n) => Ok(n as f32),
@@ -203,11 +198,14 @@ where
     D: Deserializer<'de>,
 {
     use serde::de::Error;
-    
+
     let flex = FlexId::deserialize(deserializer)?;
     match flex {
         FlexId::Number(n) => Ok(Some(n as f32)),
-        FlexId::String(s) => s.parse().map(Some).map_err(|_| D::Error::custom("invalid float")),
+        FlexId::String(s) => s
+            .parse()
+            .map(Some)
+            .map_err(|_| D::Error::custom("invalid float")),
         FlexId::Null => Ok(None),
     }
 }
@@ -215,7 +213,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_number_deserialize() {
         let json = "123";
@@ -223,21 +221,21 @@ mod tests {
         assert_eq!(id, FlexId::Number(123));
         assert_eq!(id.as_i64(), Some(123));
     }
-    
+
     #[test]
     fn test_string_deserialize() {
         let json = r#""abc123""#;
         let id: FlexId = serde_json::from_str(json).unwrap();
         assert_eq!(id, FlexId::String("abc123".to_string()));
     }
-    
+
     #[test]
     fn test_numeric_string_deserialize() {
         let json = r#""456""#;
         let id: FlexId = serde_json::from_str(json).unwrap();
         assert_eq!(id, FlexId::Number(456));
     }
-    
+
     #[test]
     fn test_null_deserialize() {
         let json = "null";

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -1967,15 +1967,15 @@ pub async fn handle_key_event(
                     }
                     KeyCode::Char('g') => {
                         if !app.vod_streams.is_empty() {
-                            app.selected_vod_stream_index = app.vod_streams.len() - 1;
-                            app.vod_stream_list_state
-                                .select(Some(app.vod_streams.len() - 1));
+                            app.selected_vod_stream_index = 0;
+                            app.vod_stream_list_state.select(Some(0));
                         }
                     }
                     KeyCode::Char('G') => {
                         if !app.vod_streams.is_empty() {
-                            app.selected_vod_stream_index = 0;
-                            app.vod_stream_list_state.select(Some(0));
+                            app.selected_vod_stream_index = app.vod_streams.len() - 1;
+                            app.vod_stream_list_state
+                                .select(Some(app.vod_streams.len() - 1));
                         }
                     }
                     KeyCode::Char('0') => {
@@ -2129,8 +2129,9 @@ pub async fn handle_key_event(
                     }
                     KeyCode::Char('G') => {
                         if !app.series_categories.is_empty() {
-                            app.selected_series_category_index = 0;
-                            app.series_category_list_state.select(Some(0));
+                            app.selected_series_category_index = app.series_categories.len() - 1;
+                            app.series_category_list_state
+                                .select(Some(app.series_categories.len() - 1));
                         }
                     }
                     KeyCode::Char('0') => {
@@ -2397,6 +2398,59 @@ pub async fn handle_key_event(
                                         app.show_play_details = true;
                                     }
                                 }
+                            }
+                        }
+                    },
+                    KeyCode::Char('g') if app.active_pane == Pane::Categories => {
+                        app.category_grid_view = !app.category_grid_view;
+                    }
+                    KeyCode::Char('G') if app.active_pane == Pane::Categories => {
+                        if !app.series_categories.is_empty() {
+                            app.selected_series_category_index = app.series_categories.len() - 1;
+                            app.series_category_list_state
+                                .select(Some(app.series_categories.len() - 1));
+                        }
+                    }
+                    KeyCode::Home => match app.active_pane {
+                        Pane::Categories => {
+                            if !app.series_categories.is_empty() {
+                                app.selected_series_category_index = 0;
+                                app.series_category_list_state.select(Some(0));
+                            }
+                        }
+                        Pane::Streams => {
+                            if !app.series_streams.is_empty() {
+                                app.selected_series_stream_index = 0;
+                                app.series_stream_list_state.select(Some(0));
+                            }
+                        }
+                        Pane::Episodes => {
+                            if !app.series_episodes.is_empty() {
+                                app.selected_series_episode_index = 0;
+                                app.series_episode_list_state.select(Some(0));
+                            }
+                        }
+                    },
+                    KeyCode::End => match app.active_pane {
+                        Pane::Categories => {
+                            if !app.series_categories.is_empty() {
+                                app.selected_series_category_index = app.series_categories.len() - 1;
+                                app.series_category_list_state
+                                    .select(Some(app.series_categories.len() - 1));
+                            }
+                        }
+                        Pane::Streams => {
+                            if !app.series_streams.is_empty() {
+                                app.selected_series_stream_index = app.series_streams.len() - 1;
+                                app.series_stream_list_state
+                                    .select(Some(app.series_streams.len() - 1));
+                            }
+                        }
+                        Pane::Episodes => {
+                            if !app.series_episodes.is_empty() {
+                                app.selected_series_episode_index = app.series_episodes.len() - 1;
+                                app.series_episode_list_state
+                                    .select(Some(app.series_episodes.len() - 1));
                             }
                         }
                     },

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -267,10 +267,12 @@ pub async fn handle_key_event(
                 }
                 #[cfg(not(feature = "chromecast"))]
                 {
-                    let _ = tx.send(AsyncAction::CastFailed(
-                        "Chromecast support not enabled. Rebuild with --features chromecast"
-                            .to_string(),
-                    ));
+                    let _ = tx
+                        .send(AsyncAction::CastFailed(
+                            "Chromecast support not enabled. Rebuild with --features chromecast"
+                                .to_string(),
+                        ))
+                        .await;
                 }
             }
             KeyCode::Enter => {
@@ -305,11 +307,12 @@ pub async fn handle_key_event(
     }
 
     // Priority 5: Global Error Overlay Dismissal
-    if app.login_error.is_some() && app.current_screen != CurrentScreen::Login {
-        if key.code == KeyCode::Esc {
-            app.login_error = None;
-            return Ok(InputResult::Continue);
-        }
+    if app.login_error.is_some()
+        && app.current_screen != CurrentScreen::Login
+        && key.code == KeyCode::Esc
+    {
+        app.login_error = None;
+        return Ok(InputResult::Continue);
     }
 
     // GLOBAL KEYS
@@ -373,31 +376,30 @@ pub async fn handle_key_event(
         }
 
         // Quick Mode Switch
-        if matches!(key.code, KeyCode::Char('m') | KeyCode::Char('M')) {
-            if app.current_screen != CurrentScreen::Settings
-                || app.settings_state != SettingsState::PlaylistModeSelection
-            {
-                if app.current_screen != CurrentScreen::Settings {
-                    app.previous_screen = Some(app.current_screen.clone());
-                }
-                app.current_screen = CurrentScreen::Settings;
-                app.settings_state = SettingsState::PlaylistModeSelection;
-
-                // Pre-select: 0 = "None" when no modes active, else first active mode (offset +1)
-                let modes = crate::config::ProcessingMode::all();
-                let idx = if app.config.processing_modes.is_empty() {
-                    0
-                } else {
-                    app.config
-                        .processing_modes
-                        .first()
-                        .and_then(|fm| modes.iter().position(|m| m == fm))
-                        .map(|i| i + 1)
-                        .unwrap_or(0)
-                };
-                app.playlist_mode_list_state.select(Some(idx));
-                return Ok(InputResult::Continue);
+        if matches!(key.code, KeyCode::Char('m') | KeyCode::Char('M'))
+            && (app.current_screen != CurrentScreen::Settings
+                || app.settings_state != SettingsState::PlaylistModeSelection)
+        {
+            if app.current_screen != CurrentScreen::Settings {
+                app.previous_screen = Some(app.current_screen.clone());
             }
+            app.current_screen = CurrentScreen::Settings;
+            app.settings_state = SettingsState::PlaylistModeSelection;
+
+            // Pre-select: 0 = "None" when no modes active, else first active mode (offset +1)
+            let modes = crate::config::ProcessingMode::all();
+            let idx = if app.config.processing_modes.is_empty() {
+                0
+            } else {
+                app.config
+                    .processing_modes
+                    .first()
+                    .and_then(|fm| modes.iter().position(|m| m == fm))
+                    .map(|i| i + 1)
+                    .unwrap_or(0)
+            };
+            app.playlist_mode_list_state.select(Some(idx));
+            return Ok(InputResult::Continue);
         }
     }
 
@@ -1777,7 +1779,7 @@ pub async fn handle_key_event(
                         }
                     }
                     KeyCode::Char('1') => {
-                        if app.vod_categories.len() > 0 {
+                        if !app.vod_categories.is_empty() {
                             app.selected_vod_category_index = 0;
                             app.vod_category_list_state.select(Some(0));
                         }
@@ -1985,7 +1987,7 @@ pub async fn handle_key_event(
                         }
                     }
                     KeyCode::Char('1') => {
-                        if app.vod_streams.len() > 0 {
+                        if !app.vod_streams.is_empty() {
                             app.selected_vod_stream_index = 0;
                             app.vod_stream_list_state.select(Some(0));
                         }
@@ -2141,7 +2143,7 @@ pub async fn handle_key_event(
                         }
                     }
                     KeyCode::Char('1') => {
-                        if app.series_categories.len() > 0 {
+                        if !app.series_categories.is_empty() {
                             app.selected_series_category_index = 0;
                             app.series_category_list_state.select(Some(0));
                         }
@@ -2384,11 +2386,8 @@ pub async fn handle_key_event(
                                 let episode =
                                     &app.series_episodes[app.selected_series_episode_index];
                                 if let Some(client) = &app.current_client {
-                                    let id = episode
-                                        .id
-                                        .as_ref()
-                                        .map(|v| get_id_str(v))
-                                        .unwrap_or_default();
+                                    let id =
+                                        episode.id.as_ref().map(get_id_str).unwrap_or_default();
                                     if !id.is_empty() {
                                         let ext =
                                             episode.container_extension.as_deref().unwrap_or("mp4");
@@ -2434,7 +2433,8 @@ pub async fn handle_key_event(
                     KeyCode::End => match app.active_pane {
                         Pane::Categories => {
                             if !app.series_categories.is_empty() {
-                                app.selected_series_category_index = app.series_categories.len() - 1;
+                                app.selected_series_category_index =
+                                    app.series_categories.len() - 1;
                                 app.series_category_list_state
                                     .select(Some(app.series_categories.len() - 1));
                             }
@@ -2530,11 +2530,8 @@ pub async fn handle_key_event(
                                 let episode =
                                     &app.series_episodes[app.selected_series_episode_index];
                                 if let Some(client) = &app.current_client {
-                                    let id = episode
-                                        .id
-                                        .as_ref()
-                                        .map(|v| get_id_str(v))
-                                        .unwrap_or_default();
+                                    let id =
+                                        episode.id.as_ref().map(get_id_str).unwrap_or_default();
                                     if !id.is_empty() {
                                         let ext =
                                             episode.container_extension.as_deref().unwrap_or("mp4");
@@ -3447,9 +3444,9 @@ pub async fn handle_key_event(
                     } else {
                         let i = match app.sports_list_state.selected() {
                             Some(i) => {
-                                if app.sports_matches.is_empty() {
-                                    0
-                                } else if i >= app.sports_matches.len() - 1 {
+                                if app.sports_matches.is_empty()
+                                    || i >= app.sports_matches.len() - 1
+                                {
                                     0
                                 } else {
                                     i + 1

--- a/src/handlers/mouse.rs
+++ b/src/handlers/mouse.rs
@@ -1,13 +1,9 @@
-use crate::app::{App, AsyncAction, CurrentScreen, Pane};
-use crossterm::event::{MouseEvent, MouseEventKind, MouseButton};
-use tokio::sync::mpsc;
 use crate::api::get_id_str;
+use crate::app::{App, AsyncAction, CurrentScreen, Pane};
+use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+use tokio::sync::mpsc;
 
-pub fn handle_mouse_event(
-    app: &mut App,
-    mouse: MouseEvent,
-    tx: &mpsc::Sender<AsyncAction>,
-) {
+pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent, tx: &mpsc::Sender<AsyncAction>) {
     match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) => {
             let x = mouse.column;
@@ -40,28 +36,40 @@ pub fn handle_mouse_event(
                         && y < app.area_categories.y + app.area_categories.height
                     {
                         app.active_pane = Pane::Categories;
-                        
+
                         let list_y = y.saturating_sub(app.area_categories.y + 1) as usize;
 
                         let current_offset = match app.current_screen {
-                            CurrentScreen::Categories | CurrentScreen::Streams => app.category_list_state.offset(),
-                            CurrentScreen::VodCategories | CurrentScreen::VodStreams => app.vod_category_list_state.offset(),
-                            CurrentScreen::SeriesCategories | CurrentScreen::SeriesStreams => app.series_category_list_state.offset(),
+                            CurrentScreen::Categories | CurrentScreen::Streams => {
+                                app.category_list_state.offset()
+                            }
+                            CurrentScreen::VodCategories | CurrentScreen::VodStreams => {
+                                app.vod_category_list_state.offset()
+                            }
+                            CurrentScreen::SeriesCategories | CurrentScreen::SeriesStreams => {
+                                app.series_category_list_state.offset()
+                            }
                             _ => 0,
                         };
 
                         let selected_idx = current_offset + list_y;
-                        let account_name = app.config.accounts.get(app.selected_account_index).map(|a| a.name.clone()).unwrap_or_default();
+                        let account_name = app
+                            .config
+                            .accounts
+                            .get(app.selected_account_index)
+                            .map(|a| a.name.clone())
+                            .unwrap_or_default();
 
                         match app.current_screen {
                             CurrentScreen::Categories | CurrentScreen::Streams => {
                                 if selected_idx < app.categories.len() {
                                     app.selected_category_index = selected_idx;
                                     app.category_list_state.select(Some(selected_idx));
-                                    
+
                                     // Trigger load for streams
                                     if let Some(client) = &app.current_client {
-                                        let cat_id = app.categories[selected_idx].category_id.clone();
+                                        let cat_id =
+                                            app.categories[selected_idx].category_id.clone();
                                         let client = client.clone();
                                         let _tx = tx.clone();
                                         let favs = app.config.favorites.streams.clone();
@@ -69,12 +77,30 @@ pub fn handle_mouse_event(
                                         let acc_name_cloned = account_name.clone();
                                         let tx_cloned = tx.clone();
                                         tokio::spawn(async move {
-                                            match client.get_live_streams(&cat_id, Some(tx_cloned.clone())).await {
+                                            match client
+                                                .get_live_streams(&cat_id, Some(tx_cloned.clone()))
+                                                .await
+                                            {
                                                 Ok(mut streams) => {
-                                                    crate::preprocessing::preprocess_streams(&mut streams, &favs, &pms, true, &acc_name_cloned, Some(tx_cloned.clone()));
-                                                    let _ = tx_cloned.send(AsyncAction::StreamsLoaded(streams, cat_id)).await;
+                                                    crate::preprocessing::preprocess_streams(
+                                                        &mut streams,
+                                                        &favs,
+                                                        &pms,
+                                                        true,
+                                                        &acc_name_cloned,
+                                                        Some(tx_cloned.clone()),
+                                                    );
+                                                    let _ = tx_cloned
+                                                        .send(AsyncAction::StreamsLoaded(
+                                                            streams, cat_id,
+                                                        ))
+                                                        .await;
                                                 }
-                                                Err(e) => { let _ = tx_cloned.send(AsyncAction::Error(e.to_string())).await; }
+                                                Err(e) => {
+                                                    let _ = tx_cloned
+                                                        .send(AsyncAction::Error(e.to_string()))
+                                                        .await;
+                                                }
                                             }
                                         });
                                     }
@@ -85,10 +111,11 @@ pub fn handle_mouse_event(
                                 if selected_idx < app.vod_categories.len() {
                                     app.selected_vod_category_index = selected_idx;
                                     app.vod_category_list_state.select(Some(selected_idx));
-                                    
+
                                     // Trigger load for VOD
                                     if let Some(client) = &app.current_client {
-                                        let cat_id = app.vod_categories[selected_idx].category_id.clone();
+                                        let cat_id =
+                                            app.vod_categories[selected_idx].category_id.clone();
                                         app.state_loading = true;
                                         app.active_pane = Pane::Streams;
                                         let client = client.clone();
@@ -100,10 +127,25 @@ pub fn handle_mouse_event(
                                         tokio::spawn(async move {
                                             match client.get_vod_streams(&cat_id).await {
                                                 Ok(mut streams) => {
-                                                    crate::preprocessing::preprocess_streams(&mut streams, &favs, &pms, false, &acc_name_cloned, Some(tx_cloned.clone()));
-                                                    let _ = tx_cloned.send(AsyncAction::VodStreamsLoaded(streams, cat_id)).await;
+                                                    crate::preprocessing::preprocess_streams(
+                                                        &mut streams,
+                                                        &favs,
+                                                        &pms,
+                                                        false,
+                                                        &acc_name_cloned,
+                                                        Some(tx_cloned.clone()),
+                                                    );
+                                                    let _ = tx_cloned
+                                                        .send(AsyncAction::VodStreamsLoaded(
+                                                            streams, cat_id,
+                                                        ))
+                                                        .await;
                                                 }
-                                                Err(e) => { let _ = tx_cloned.send(AsyncAction::Error(e.to_string())).await; }
+                                                Err(e) => {
+                                                    let _ = tx_cloned
+                                                        .send(AsyncAction::Error(e.to_string()))
+                                                        .await;
+                                                }
                                             }
                                         });
                                     }
@@ -114,10 +156,11 @@ pub fn handle_mouse_event(
                                 if selected_idx < app.series_categories.len() {
                                     app.selected_series_category_index = selected_idx;
                                     app.series_category_list_state.select(Some(selected_idx));
-                                    
+
                                     // Trigger load for Series
                                     if let Some(client) = &app.current_client {
-                                        let cat_id = app.series_categories[selected_idx].category_id.clone();
+                                        let cat_id =
+                                            app.series_categories[selected_idx].category_id.clone();
                                         let client = client.clone();
                                         let tx = tx.clone();
                                         let pms = app.config.processing_modes.clone();
@@ -129,10 +172,25 @@ pub fn handle_mouse_event(
                                         tokio::spawn(async move {
                                             match client.get_series_streams(&cat_id).await {
                                                 Ok(mut streams) => {
-                                                    crate::preprocessing::preprocess_streams(&mut streams, &favs, &pms, false, &acc_name_cloned, Some(tx_cloned.clone()));
-                                                    let _ = tx_cloned.send(AsyncAction::SeriesStreamsLoaded(streams, cat_id)).await;
+                                                    crate::preprocessing::preprocess_streams(
+                                                        &mut streams,
+                                                        &favs,
+                                                        &pms,
+                                                        false,
+                                                        &acc_name_cloned,
+                                                        Some(tx_cloned.clone()),
+                                                    );
+                                                    let _ = tx_cloned
+                                                        .send(AsyncAction::SeriesStreamsLoaded(
+                                                            streams, cat_id,
+                                                        ))
+                                                        .await;
                                                 }
-                                                Err(e) => { let _ = tx_cloned.send(AsyncAction::Error(e.to_string())).await; }
+                                                Err(e) => {
+                                                    let _ = tx_cloned
+                                                        .send(AsyncAction::Error(e.to_string()))
+                                                        .await;
+                                                }
                                             }
                                         });
                                     }
@@ -147,13 +205,19 @@ pub fn handle_mouse_event(
                         && y < app.area_streams.y + app.area_streams.height
                     {
                         app.active_pane = Pane::Streams;
-                        
+
                         let list_y = y.saturating_sub(app.area_streams.y + 1) as usize;
 
                         let current_offset = match app.current_screen {
-                            CurrentScreen::Categories | CurrentScreen::Streams => app.stream_list_state.offset(),
-                            CurrentScreen::VodCategories | CurrentScreen::VodStreams => app.vod_stream_list_state.offset(),
-                            CurrentScreen::SeriesCategories | CurrentScreen::SeriesStreams => app.series_stream_list_state.offset(),
+                            CurrentScreen::Categories | CurrentScreen::Streams => {
+                                app.stream_list_state.offset()
+                            }
+                            CurrentScreen::VodCategories | CurrentScreen::VodStreams => {
+                                app.vod_stream_list_state.offset()
+                            }
+                            CurrentScreen::SeriesCategories | CurrentScreen::SeriesStreams => {
+                                app.series_stream_list_state.offset()
+                            }
                             CurrentScreen::GlobalSearch => app.global_search_list_state.offset(),
                             _ => 0,
                         };
@@ -165,7 +229,7 @@ pub fn handle_mouse_event(
                                 if selected_idx < app.streams.len() {
                                     app.selected_stream_index = selected_idx;
                                     app.stream_list_state.select(Some(selected_idx));
-                                    
+
                                     // Trigger Stream Player
                                     if let Some(client) = &app.current_client {
                                         let stream = &app.streams[selected_idx];
@@ -174,10 +238,11 @@ pub fn handle_mouse_event(
                                         let _tx = tx.clone();
                                         app.state_loading = true;
                                         app.player_error = None;
-                                        app.loading_message = Some(format!("Preparing: {}...", stream.name));
-                                        
-                                        // The player playback action usually needs handle_key_event's player ref or 
-                                        // we just let the main loop or handle_key_event do playback proper. 
+                                        app.loading_message =
+                                            Some(format!("Preparing: {}...", stream.name));
+
+                                        // The player playback action usually needs handle_key_event's player ref or
+                                        // we just let the main loop or handle_key_event do playback proper.
                                         // In TUI, best if we just delegate it: create a new popup/play pending state
                                         app.pending_play_url = Some(url);
                                         app.pending_play_title = Some(stream.name.clone());
@@ -189,12 +254,13 @@ pub fn handle_mouse_event(
                                 if selected_idx < app.vod_streams.len() {
                                     app.selected_vod_stream_index = selected_idx;
                                     app.vod_stream_list_state.select(Some(selected_idx));
-                                    
+
                                     // Trigger VOD detail playback
                                     if let Some(client) = &app.current_client {
                                         let stream = &app.vod_streams[selected_idx];
                                         let id = get_id_str(&stream.stream_id);
-                                        let extension = stream.container_extension.as_deref().unwrap_or("mp4");
+                                        let extension =
+                                            stream.container_extension.as_deref().unwrap_or("mp4");
                                         let url = client.get_vod_url(&id, extension);
                                         app.pending_play_url = Some(url);
                                         app.pending_play_title = Some(stream.name.clone());
@@ -206,7 +272,7 @@ pub fn handle_mouse_event(
                                 if selected_idx < app.series_streams.len() {
                                     app.selected_series_stream_index = selected_idx;
                                     app.series_stream_list_state.select(Some(selected_idx));
-                                    
+
                                     // Trigger Series episode loading
                                     if let Some(client) = &app.current_client {
                                         let stream = &app.series_streams[selected_idx];
@@ -215,12 +281,20 @@ pub fn handle_mouse_event(
                                         app.active_pane = Pane::Episodes;
                                         let tx_cloned = tx.clone();
                                         let client = client.clone();
-                                tokio::spawn(async move {
-                                    match client.get_series_info(&id).await {
-                                        Ok(info) => { let _ = tx_cloned.send(AsyncAction::SeriesInfoLoaded(info)).await; }
-                                        Err(e) => { let _ = tx_cloned.send(AsyncAction::Error(e.to_string())).await; }
-                                    }
-                                });
+                                        tokio::spawn(async move {
+                                            match client.get_series_info(&id).await {
+                                                Ok(info) => {
+                                                    let _ = tx_cloned
+                                                        .send(AsyncAction::SeriesInfoLoaded(info))
+                                                        .await;
+                                                }
+                                                Err(e) => {
+                                                    let _ = tx_cloned
+                                                        .send(AsyncAction::Error(e.to_string()))
+                                                        .await;
+                                                }
+                                            }
+                                        });
                                     }
                                 }
                             }
@@ -231,14 +305,17 @@ pub fn handle_mouse_event(
                                     if let Some(client) = &app.current_client {
                                         let stream = &app.global_search_results[selected_idx];
                                         let id = get_id_str(&stream.stream_id);
-                                        let extension = stream.container_extension.as_deref().unwrap_or("ts");
+                                        let extension =
+                                            stream.container_extension.as_deref().unwrap_or("ts");
                                         let url = match stream.stream_type.as_str() {
                                             "movie" => client.get_vod_url(&id, extension),
                                             "series" => client.get_series_url(&id, extension),
                                             _ => client.get_stream_url(&id, "ts"), // Force TS for live streams
                                         };
 
-                                        if stream.stream_type == "movie" || stream.stream_type == "series" {
+                                        if stream.stream_type == "movie"
+                                            || stream.stream_type == "series"
+                                        {
                                             app.pending_play_url = Some(url);
                                             app.pending_play_title = Some(stream.name.clone());
                                             app.show_play_details = true;
@@ -251,33 +328,34 @@ pub fn handle_mouse_event(
                             }
                             _ => {}
                         }
-                    } else if x >= app.area_episodes.x 
-                        && x < app.area_episodes.x + app.area_episodes.width 
-                        && y >= app.area_episodes.y 
+                    } else if x >= app.area_episodes.x
+                        && x < app.area_episodes.x + app.area_episodes.width
+                        && y >= app.area_episodes.y
                         && y < app.area_episodes.y + app.area_episodes.height
-                        && app.active_pane == Pane::Episodes 
+                        && app.active_pane == Pane::Episodes
                     {
-                         // Series episode selection click support
-                         let list_y = y.saturating_sub(app.area_episodes.y + 1) as usize;
-                         let current_offset = app.series_episode_list_state.offset();
-                         let selected_idx = current_offset + list_y;
+                        // Series episode selection click support
+                        let list_y = y.saturating_sub(app.area_episodes.y + 1) as usize;
+                        let current_offset = app.series_episode_list_state.offset();
+                        let selected_idx = current_offset + list_y;
 
-                         if selected_idx < app.series_episodes.len() {
-                             app.selected_series_episode_index = selected_idx;
-                             app.series_episode_list_state.select(Some(selected_idx));
+                        if selected_idx < app.series_episodes.len() {
+                            app.selected_series_episode_index = selected_idx;
+                            app.series_episode_list_state.select(Some(selected_idx));
 
-                             let episode = &app.series_episodes[app.selected_series_episode_index];
-                             if let Some(client) = &app.current_client {
-                                 let id = episode.id.as_ref().map(|v| get_id_str(v)).unwrap_or_default();
-                                 if !id.is_empty() {
-                                     let ext = episode.container_extension.as_deref().unwrap_or("mp4");
-                                     let url = client.get_series_url(&id, ext);
-                                     app.pending_play_url = Some(url);
-                                     app.pending_play_title = episode.title.clone();
-                                     app.show_play_details = true;
-                                 }
-                             }
-                         }
+                            let episode = &app.series_episodes[app.selected_series_episode_index];
+                            if let Some(client) = &app.current_client {
+                                let id = episode.id.as_ref().map(get_id_str).unwrap_or_default();
+                                if !id.is_empty() {
+                                    let ext =
+                                        episode.container_extension.as_deref().unwrap_or("mp4");
+                                    let url = client.get_series_url(&id, ext);
+                                    app.pending_play_url = Some(url);
+                                    app.pending_play_title = episode.title.clone();
+                                    app.show_play_details = true;
+                                }
+                            }
+                        }
                     }
                 }
                 CurrentScreen::SportsDashboard => {
@@ -294,17 +372,25 @@ pub fn handle_mouse_event(
                             app.sports_category_list_state.select(Some(selected_idx));
                             app.sports_matches.clear();
                             app.current_sports_streams.clear();
-                            
+
                             let category = app.sports_categories[selected_idx].clone();
                             app.state_loading = true;
                             let tx = tx.clone();
-                            
+
                             let tx_cloned = tx.clone();
                             tokio::spawn(async move {
-                                if let Ok(matches) = crate::sports::fetch_streamed_matches(&category).await {
-                                    let _ = tx_cloned.send(crate::app::AsyncAction::SportsMatchesLoaded(matches)).await;
+                                if let Ok(matches) =
+                                    crate::sports::fetch_streamed_matches(&category).await
+                                {
+                                    let _ = tx_cloned
+                                        .send(crate::app::AsyncAction::SportsMatchesLoaded(matches))
+                                        .await;
                                 } else {
-                                    let _ = tx_cloned.send(crate::app::AsyncAction::Error(format!("Failed to load sports"))).await;
+                                    let _ = tx_cloned
+                                        .send(crate::app::AsyncAction::Error(
+                                            "Failed to load sports".to_string(),
+                                        ))
+                                        .await;
                                 }
                             });
                         }
@@ -317,30 +403,37 @@ pub fn handle_mouse_event(
                         let list_y = y.saturating_sub(app.area_streams.y + 1) as usize;
                         let current_offset = app.sports_list_state.offset();
                         let selected_idx: usize = current_offset + list_y;
-                        
+
                         if selected_idx < app.sports_matches.len() {
                             app.sports_list_state.select(Some(selected_idx));
                             app.active_pane = Pane::Episodes; // Move right to sources
                         }
-                    } else if x >= app.area_episodes.x 
-                        && x < app.area_episodes.x + app.area_episodes.width 
-                        && y >= app.area_episodes.y 
+                    } else if x >= app.area_episodes.x
+                        && x < app.area_episodes.x + app.area_episodes.width
+                        && y >= app.area_episodes.y
                         && y < app.area_episodes.y + app.area_episodes.height
-                        && app.active_pane == Pane::Episodes 
+                        && app.active_pane == Pane::Episodes
                     {
                         // Sports stream source selection
                         let list_y = y.saturating_sub(app.area_episodes.y + 1) as usize;
                         let selected_idx: usize = list_y; // Assume no scrolling offset for sources
-                        
+
                         if selected_idx < app.current_sports_streams.len() {
                             let stream = &app.current_sports_streams[selected_idx];
                             let stream_url = &stream.embed_url;
-                            let match_title = if let Some(m_idx) = app.sports_list_state.selected() {
-                                if m_idx < app.sports_matches.len() { app.sports_matches[m_idx].title.clone() } else { "Sports".to_string() }
-                            } else { "Sports".to_string() };
-                            
+                            let match_title = if let Some(m_idx) = app.sports_list_state.selected()
+                            {
+                                if m_idx < app.sports_matches.len() {
+                                    app.sports_matches[m_idx].title.clone()
+                                } else {
+                                    "Sports".to_string()
+                                }
+                            } else {
+                                "Sports".to_string()
+                            };
+
                             let stream_title = format!("{} ({})", match_title, stream.source);
-                            
+
                             app.pending_play_url = Some(stream_url.clone());
                             app.pending_play_title = Some(stream_title);
                         }
@@ -355,13 +448,11 @@ pub fn handle_mouse_event(
             } else {
                 match app.current_screen {
                     CurrentScreen::Home => app.next_account(),
-                    CurrentScreen::Categories | CurrentScreen::Streams => {
-                        match app.active_pane {
-                            Pane::Categories => app.next_category(),
-                            Pane::Streams => app.next_stream(),
-                            _ => {}
-                        }
-                    }
+                    CurrentScreen::Categories | CurrentScreen::Streams => match app.active_pane {
+                        Pane::Categories => app.next_category(),
+                        Pane::Streams => app.next_stream(),
+                        _ => {}
+                    },
                     CurrentScreen::VodCategories | CurrentScreen::VodStreams => {
                         match app.active_pane {
                             Pane::Categories => app.next_vod_category(),
@@ -379,16 +470,22 @@ pub fn handle_mouse_event(
                     CurrentScreen::SportsDashboard => {
                         match app.active_pane {
                             Pane::Categories => {
-                                app.selected_sports_category_index = app.selected_sports_category_index.saturating_add(1).min(app.sports_categories.len().saturating_sub(1));
-                                app.sports_category_list_state.select(Some(app.selected_sports_category_index));
+                                app.selected_sports_category_index = app
+                                    .selected_sports_category_index
+                                    .saturating_add(1)
+                                    .min(app.sports_categories.len().saturating_sub(1));
+                                app.sports_category_list_state
+                                    .select(Some(app.selected_sports_category_index));
                             }
                             Pane::Streams => {
                                 if let Some(mut selected) = app.sports_list_state.selected() {
-                                    selected = selected.saturating_add(1).min(app.sports_matches.len().saturating_sub(1));
+                                    selected = selected
+                                        .saturating_add(1)
+                                        .min(app.sports_matches.len().saturating_sub(1));
                                     app.sports_list_state.select(Some(selected));
                                 }
                             }
-                            Pane::Episodes => {}, // No scrolling for stream array yet
+                            Pane::Episodes => {} // No scrolling for stream array yet
                         }
                     }
                     CurrentScreen::Settings => app.next_setting(),
@@ -403,13 +500,11 @@ pub fn handle_mouse_event(
             } else {
                 match app.current_screen {
                     CurrentScreen::Home => app.previous_account(),
-                    CurrentScreen::Categories | CurrentScreen::Streams => {
-                        match app.active_pane {
-                            Pane::Categories => app.previous_category(),
-                            Pane::Streams => app.previous_stream(),
-                            _ => {}
-                        }
-                    }
+                    CurrentScreen::Categories | CurrentScreen::Streams => match app.active_pane {
+                        Pane::Categories => app.previous_category(),
+                        Pane::Streams => app.previous_stream(),
+                        _ => {}
+                    },
                     CurrentScreen::VodCategories | CurrentScreen::VodStreams => {
                         match app.active_pane {
                             Pane::Categories => app.previous_vod_category(),
@@ -424,21 +519,21 @@ pub fn handle_mouse_event(
                             Pane::Episodes => app.previous_series_episode(),
                         }
                     }
-                    CurrentScreen::SportsDashboard => {
-                        match app.active_pane {
-                            Pane::Categories => {
-                                app.selected_sports_category_index = app.selected_sports_category_index.saturating_sub(1);
-                                app.sports_category_list_state.select(Some(app.selected_sports_category_index));
-                            }
-                            Pane::Streams => {
-                                if let Some(mut selected) = app.sports_list_state.selected() {
-                                    selected = selected.saturating_sub(1);
-                                    app.sports_list_state.select(Some(selected));
-                                }
-                            }
-                            Pane::Episodes => {},
+                    CurrentScreen::SportsDashboard => match app.active_pane {
+                        Pane::Categories => {
+                            app.selected_sports_category_index =
+                                app.selected_sports_category_index.saturating_sub(1);
+                            app.sports_category_list_state
+                                .select(Some(app.selected_sports_category_index));
                         }
-                    }
+                        Pane::Streams => {
+                            if let Some(mut selected) = app.sports_list_state.selected() {
+                                selected = selected.saturating_sub(1);
+                                app.sports_list_state.select(Some(selected));
+                            }
+                        }
+                        Pane::Episodes => {}
+                    },
                     CurrentScreen::Settings => app.previous_setting(),
                     CurrentScreen::GlobalSearch => app.previous_global_search_result(),
                     _ => {}

--- a/src/m3u_parser.rs
+++ b/src/m3u_parser.rs
@@ -1,15 +1,15 @@
-/// M3U/M3U8 playlist parser for IPTV catalog ingestion.
-///
-/// Parses the extended M3U format (`#EXTM3U` + `#EXTINF` lines) commonly distributed
-/// by IPTV providers. This is distinct from HLS segment playlists — this module handles
-/// *catalog* playlists that list channel URLs with metadata tags.
-///
-/// # Format example
-/// ```text
-/// #EXTM3U
-/// #EXTINF:-1 tvg-id="cnn.us" tvg-name="CNN" tvg-logo="http://..." group-title="News",CNN
-/// http://provider.example/live/user/pass/12345.ts
-/// ```
+//! M3U/M3U8 playlist parser for IPTV catalog ingestion.
+//!
+//! Parses the extended M3U format (`#EXTM3U` + `#EXTINF` lines) commonly distributed
+//! by IPTV providers. This is distinct from HLS segment playlists — this module handles
+//! *catalog* playlists that list channel URLs with metadata tags.
+//!
+//! # Format example
+//! ```text
+//! #EXTM3U
+//! #EXTINF:-1 tvg-id="cnn.us" tvg-name="CNN" tvg-logo="http://..." group-title="News",CNN
+//! http://provider.example/live/user/pass/12345.ts
+//! ```
 
 /// A single entry parsed from an M3U playlist.
 #[derive(Debug, Clone, PartialEq)]
@@ -56,9 +56,8 @@ fn extract_attr<'a>(line: &'a str, key: &str) -> &'a str {
     let search = format!("{}=", key);
     if let Some(pos) = line.find(&search) {
         let rest = &line[pos + search.len()..];
-        if rest.starts_with('"') {
+        if let Some(inner) = rest.strip_prefix('"') {
             // Quoted value: find the closing quote
-            let inner = &rest[1..];
             if let Some(end) = inner.find('"') {
                 return &inner[..end];
             }
@@ -66,9 +65,7 @@ fn extract_attr<'a>(line: &'a str, key: &str) -> &'a str {
             return inner;
         } else {
             // Unquoted value: terminate at space or comma
-            let end = rest
-                .find(|c: char| c == ' ' || c == ',')
-                .unwrap_or(rest.len());
+            let end = rest.find([' ', ',']).unwrap_or(rest.len());
             return &rest[..end];
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,16 +5,19 @@ use tokio::time::interval;
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event},
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen, Clear, ClearType},
+    terminal::{
+        disable_raw_mode, enable_raw_mode, Clear, ClearType, EnterAlternateScreen,
+        LeaveAlternateScreen,
+    },
 };
 
+use matrix_iptv_lib::api::get_id_str;
+use matrix_iptv_lib::app::{App, AsyncAction, CurrentScreen, Pane};
+use matrix_iptv_lib::{handlers, player, setup, sports, ui};
 #[cfg(not(target_arch = "wasm32"))]
 use ratatui::{backend::CrosstermBackend, Terminal};
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::sync::mpsc;
-use matrix_iptv_lib::app::{App, AsyncAction, CurrentScreen, Pane};
-use matrix_iptv_lib::api::get_id_str;
-use matrix_iptv_lib::{player, setup, ui, handlers, sports};
 
 #[derive(clap::Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -54,7 +57,14 @@ async fn main() -> Result<(), anyhow::Error> {
         setup::check_and_install_dependencies()?;
         let player = player::Player::new();
         println!("Playing: {}", url);
-        player.play(&url, matrix_iptv_lib::config::PlayerEngine::Vlc, false, true).await?; // Use optimized VLC with smoothing for CLI play
+        player
+            .play(
+                &url,
+                matrix_iptv_lib::config::PlayerEngine::Vlc,
+                false,
+                true,
+            )
+            .await?; // Use optimized VLC with smoothing for CLI play
         return Ok(());
     }
 
@@ -66,7 +76,12 @@ async fn main() -> Result<(), anyhow::Error> {
     // Setup Terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture, Clear(ClearType::All))?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        Clear(ClearType::All)
+    )?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -117,14 +132,14 @@ async fn main() -> Result<(), anyhow::Error> {
         let service = matrix_iptv_lib::scores::ScoreService::new();
         // Initial fetch delayed by 5s to allow startup
         tokio::time::sleep(Duration::from_secs(5)).await;
-        
+
         // Loop every 60s
         let mut ticker = interval(Duration::from_secs(60));
         loop {
-            ticker.tick().await; 
-             if let Ok(scores) = service.fetch_scores().await {
-                 let _ = tx_scores.send(AsyncAction::ScoresLoaded(scores)).await;
-             }
+            ticker.tick().await;
+            if let Ok(scores) = service.fetch_scores().await {
+                let _ = tx_scores.send(AsyncAction::ScoresLoaded(scores)).await;
+            }
         }
     });
 
@@ -174,11 +189,13 @@ async fn run_app<B: ratatui::backend::Backend>(
             app.needs_stream_refresh = false;
             needs_redraw = true;
         }
-        
+
         // Debounce expired: the full UI projection is now zero-cost and renders immediately.
 
         if needs_redraw {
-            terminal.draw(|f| ui::ui(f, app)).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+            terminal
+                .draw(|f| ui::ui(f, app))
+                .map_err(|e| std::io::Error::other(e.to_string()))?;
             needs_redraw = false;
         }
 
@@ -200,7 +217,10 @@ async fn run_app<B: ratatui::backend::Backend>(
         }
 
         // 1.5 Debounced EPG Fetching
-        if app.current_screen == CurrentScreen::Streams && app.active_pane == Pane::Streams && !app.streams.is_empty() {
+        if app.current_screen == CurrentScreen::Streams
+            && app.active_pane == Pane::Streams
+            && !app.streams.is_empty()
+        {
             let focused_id = get_id_str(&app.streams[app.selected_stream_index].stream_id);
             if app.last_focused_stream_id.as_ref() != Some(&focused_id) {
                 app.last_focused_stream_id = Some(focused_id.clone());
@@ -215,8 +235,13 @@ async fn run_app<B: ratatui::backend::Backend>(
                             let fid = focused_id.clone();
                             tokio::spawn(async move {
                                 if let Ok(epg) = client.get_short_epg(&fid).await {
-                                    if let Some(now_playing) = epg.epg_listings.get(0) {
-                                        let _ = tx.send(AsyncAction::EpgLoaded(fid, now_playing.title.clone())).await;
+                                    if let Some(now_playing) = epg.epg_listings.first() {
+                                        let _ = tx
+                                            .send(AsyncAction::EpgLoaded(
+                                                fid,
+                                                now_playing.title.clone(),
+                                            ))
+                                            .await;
                                     }
                                 }
                             });
@@ -227,9 +252,12 @@ async fn run_app<B: ratatui::backend::Backend>(
         }
 
         // 1.6 Debounced Stream Health Check
-        if (app.current_screen == CurrentScreen::Streams && app.active_pane == Pane::Streams && !app.streams.is_empty()) ||
-           (app.current_screen == CurrentScreen::GlobalSearch && !app.global_search_results.is_empty()) {
-            
+        if (app.current_screen == CurrentScreen::Streams
+            && app.active_pane == Pane::Streams
+            && !app.streams.is_empty())
+            || (app.current_screen == CurrentScreen::GlobalSearch
+                && !app.global_search_results.is_empty())
+        {
             let focused_stream = if app.current_screen == CurrentScreen::GlobalSearch {
                 app.global_search_results.get(app.selected_stream_index)
             } else {
@@ -245,7 +273,7 @@ async fn run_app<B: ratatui::backend::Backend>(
                         let fid = focused_id.clone();
                         let ext = stream.container_extension.as_deref().unwrap_or("ts");
                         let url = client.get_stream_url(&fid, ext);
-                        
+
                         // We use a small delay to avoid spamming while scrolling
                         if app.focus_timestamp.is_none() {
                             app.focus_timestamp = Some(std::time::Instant::now());
@@ -257,16 +285,21 @@ async fn run_app<B: ratatui::backend::Backend>(
                                     .timeout(std::time::Duration::from_secs(3))
                                     .build()
                                     .unwrap_or_default();
-                                
+
                                 if let Ok(resp) = req_client.head(&url).send().await {
                                     if resp.status().is_success() {
                                         let latency = start.elapsed().as_millis() as u64;
-                                        let _ = tx.send(AsyncAction::StreamHealthLoaded(fid, latency)).await;
+                                        let _ = tx
+                                            .send(AsyncAction::StreamHealthLoaded(fid, latency))
+                                            .await;
                                     } else {
-                                        let _ = tx.send(AsyncAction::StreamHealthLoaded(fid, 2000)).await;
+                                        let _ = tx
+                                            .send(AsyncAction::StreamHealthLoaded(fid, 2000))
+                                            .await;
                                     }
                                 } else {
-                                    let _ = tx.send(AsyncAction::StreamHealthLoaded(fid, 5000)).await;
+                                    let _ =
+                                        tx.send(AsyncAction::StreamHealthLoaded(fid, 5000)).await;
                                 }
                             });
                         }
@@ -274,9 +307,12 @@ async fn run_app<B: ratatui::backend::Backend>(
                 }
             }
         }
-        
+
         // 1.7 Debounced VOD Info Fetching
-        if app.current_screen == CurrentScreen::VodStreams && app.active_pane == Pane::Streams && !app.vod_streams.is_empty() {
+        if app.current_screen == CurrentScreen::VodStreams
+            && app.active_pane == Pane::Streams
+            && !app.vod_streams.is_empty()
+        {
             let focused_id = get_id_str(&app.vod_streams[app.selected_vod_stream_index].stream_id);
             if app.last_focused_stream_id.as_ref() != Some(&focused_id) {
                 app.last_focused_stream_id = Some(focused_id.clone());
@@ -299,8 +335,12 @@ async fn run_app<B: ratatui::backend::Backend>(
         }
 
         // 1.7.5 Debounced Series Info Fetching
-        if app.current_screen == CurrentScreen::SeriesStreams && app.active_pane == Pane::Streams && !app.series_streams.is_empty() {
-            let focused_id = get_id_str(&app.series_streams[app.selected_series_stream_index].stream_id);
+        if app.current_screen == CurrentScreen::SeriesStreams
+            && app.active_pane == Pane::Streams
+            && !app.series_streams.is_empty()
+        {
+            let focused_id =
+                get_id_str(&app.series_streams[app.selected_series_stream_index].stream_id);
             if app.last_focused_stream_id.as_ref() != Some(&focused_id) {
                 app.last_focused_stream_id = Some(focused_id.clone());
                 app.focus_timestamp = Some(std::time::Instant::now());
@@ -322,7 +362,9 @@ async fn run_app<B: ratatui::backend::Backend>(
         }
 
         // 1.8 Debounced Info Fetching for Global Search
-        if app.current_screen == CurrentScreen::GlobalSearch && !app.global_search_results.is_empty() {
+        if app.current_screen == CurrentScreen::GlobalSearch
+            && !app.global_search_results.is_empty()
+        {
             let stream = &app.global_search_results[app.selected_stream_index];
             if stream.stream_type == "movie" || stream.stream_type == "series" {
                 let focused_id = get_id_str(&stream.stream_id);
@@ -342,10 +384,8 @@ async fn run_app<B: ratatui::backend::Backend>(
                                     if let Ok(info) = client.get_series_info(&fid).await {
                                         let _ = tx.send(AsyncAction::SeriesInfoLoaded(info)).await;
                                     }
-                                } else {
-                                    if let Ok(info) = client.get_vod_info(&fid).await {
-                                        let _ = tx.send(AsyncAction::VodInfoLoaded(info)).await;
-                                    }
+                                } else if let Ok(info) = client.get_vod_info(&fid).await {
+                                    let _ = tx.send(AsyncAction::VodInfoLoaded(info)).await;
                                 }
                             });
                         }
@@ -355,7 +395,10 @@ async fn run_app<B: ratatui::backend::Backend>(
         }
 
         // 1.10 Debounced Sports Info Fetching (Matches list)
-        if app.current_screen == CurrentScreen::SportsDashboard && app.sports_matches.is_empty() && !app.state_loading {
+        if app.current_screen == CurrentScreen::SportsDashboard
+            && app.sports_matches.is_empty()
+            && !app.state_loading
+        {
             let tx = tx.clone();
             let category = app.sports_categories[app.selected_sports_category_index].clone();
             app.state_loading = true;
@@ -363,14 +406,21 @@ async fn run_app<B: ratatui::backend::Backend>(
                 if let Ok(matches) = sports::fetch_streamed_matches(&category).await {
                     let _ = tx.send(AsyncAction::SportsMatchesLoaded(matches)).await;
                 } else {
-                    let _ = tx.send(AsyncAction::Error("System Protocol: Failed to link with sports uplink.".to_string())).await;
+                    let _ = tx
+                        .send(AsyncAction::Error(
+                            "System Protocol: Failed to link with sports uplink.".to_string(),
+                        ))
+                        .await;
                 }
             });
         }
 
         // 1.11 Debounced Sports Stream Link Fetching
         if app.current_screen == CurrentScreen::SportsDashboard && !app.sports_matches.is_empty() {
-            if let Some(selected_match) = app.sports_matches.get(app.sports_list_state.selected().unwrap_or(0)) {
+            if let Some(selected_match) = app
+                .sports_matches
+                .get(app.sports_list_state.selected().unwrap_or(0))
+            {
                 let focused_id = selected_match.id.clone();
                 if app.last_focused_stream_id.as_ref() != Some(&focused_id) {
                     app.last_focused_stream_id = Some(focused_id.clone());
@@ -385,7 +435,9 @@ async fn run_app<B: ratatui::backend::Backend>(
                             let source_name = source.source.clone();
                             let source_id = source.id.clone();
                             tokio::spawn(async move {
-                                if let Ok(links) = sports::fetch_streamed_links(&source_name, &source_id).await {
+                                if let Ok(links) =
+                                    sports::fetch_streamed_links(&source_name, &source_id).await
+                                {
                                     let _ = tx.send(AsyncAction::SportsStreamsLoaded(links)).await;
                                 }
                             });
@@ -397,7 +449,10 @@ async fn run_app<B: ratatui::backend::Backend>(
 
         // 1.12 Debounced Sports Matching for regular streams
         // Use cached_parsed to avoid expensive parse_stream() calls every frame
-        if (app.current_screen == CurrentScreen::Streams || app.current_screen == CurrentScreen::GlobalSearch) && app.active_pane == Pane::Streams {
+        if (app.current_screen == CurrentScreen::Streams
+            || app.current_screen == CurrentScreen::GlobalSearch)
+            && app.active_pane == Pane::Streams
+        {
             let focused_stream = if app.current_screen == CurrentScreen::GlobalSearch {
                 app.global_search_results.get(app.selected_stream_index)
             } else {
@@ -425,19 +480,31 @@ async fn run_app<B: ratatui::backend::Backend>(
                             let (team1, team2) = if let Some(ref cached) = stream.cached_parsed {
                                 if let Some(ref ev) = cached.sports_event {
                                     (ev.team1.clone(), ev.team2.clone())
-                                } else { continue; }
-                            } else { continue; };
-                            
+                                } else {
+                                    continue;
+                                }
+                            } else {
+                                continue;
+                            };
+
                             tokio::spawn(async move {
                                 if let Ok(matches) = sports::fetch_streamed_matches("live").await {
                                     let found = matches.into_iter().find(|m| {
                                         let title = m.title.to_lowercase();
-                                        title.contains(&team1.to_lowercase()) || title.contains(&team2.to_lowercase())
+                                        title.contains(&team1.to_lowercase())
+                                            || title.contains(&team2.to_lowercase())
                                     });
                                     if let Some(m) = found {
                                         if let Some(source) = m.sources.first() {
-                                            if let Ok(links) = sports::fetch_streamed_links(&source.source, &source.id).await {
-                                                let _ = tx.send(AsyncAction::SportsStreamsLoaded(links)).await;
+                                            if let Ok(links) = sports::fetch_streamed_links(
+                                                &source.source,
+                                                &source.id,
+                                            )
+                                            .await
+                                            {
+                                                let _ = tx
+                                                    .send(AsyncAction::SportsStreamsLoaded(links))
+                                                    .await;
                                             }
                                         }
                                     }
@@ -448,7 +515,7 @@ async fn run_app<B: ratatui::backend::Backend>(
                 }
             }
         }
-        
+
         // FTUE: Handle Matrix rain animation
         if app.show_matrix_rain {
             if let Ok(size) = terminal.size() {
@@ -457,19 +524,19 @@ async fn run_app<B: ratatui::backend::Backend>(
                 if app.matrix_rain_columns.is_empty() {
                     app.matrix_rain_columns = matrix_iptv_lib::matrix_rain::init_matrix_rain(rect);
                 }
-                
+
                 // Update animation
                 matrix_iptv_lib::matrix_rain::update_matrix_rain(
-                    &mut app.matrix_rain_columns, 
-                    rect, 
-                    app.loading_tick, 
-                    &mut app.matrix_rain_logo_hits, 
-                    !app.matrix_rain_screensaver_mode
+                    &mut app.matrix_rain_columns,
+                    rect,
+                    app.loading_tick,
+                    &mut app.matrix_rain_logo_hits,
+                    !app.matrix_rain_screensaver_mode,
                 );
-                
+
                 // Force continuous terminal redraws during animation sequences
                 needs_redraw = true;
-                
+
                 // Only end startup animation after 3 seconds (screensaver runs indefinitely)
                 if !app.matrix_rain_screensaver_mode {
                     if let Some(start_time) = app.matrix_rain_start_time {
@@ -497,19 +564,33 @@ async fn run_app<B: ratatui::backend::Backend>(
                     match handlers::input::handle_key_event(app, key, &tx, player).await? {
                         handlers::input::InputResult::Quit => return Ok(None),
                         handlers::input::InputResult::UpdateRequested => return Ok(Some(42)),
-                        handlers::input::InputResult::Continue => { needs_redraw = true; continue; },
-                        handlers::input::InputResult::Ok => { needs_redraw = true; }
+                        handlers::input::InputResult::Continue => {
+                            needs_redraw = true;
+                            continue;
+                        }
+                        handlers::input::InputResult::Ok => {
+                            needs_redraw = true;
+                        }
                     }
                     // ── Input Coalescing: drain queued keys without redrawing ──
                     // When scrolling fast, multiple key events queue up. Process them
                     // all in one batch to avoid 33ms render + debounce between each.
                     while event::poll(Duration::from_millis(0))? {
                         if let Event::Key(next_key) = event::read()? {
-                            match handlers::input::handle_key_event(app, next_key, &tx, player).await? {
+                            match handlers::input::handle_key_event(app, next_key, &tx, player)
+                                .await?
+                            {
                                 handlers::input::InputResult::Quit => return Ok(None),
-                                handlers::input::InputResult::UpdateRequested => return Ok(Some(42)),
-                                handlers::input::InputResult::Continue => { needs_redraw = true; continue; },
-                                handlers::input::InputResult::Ok => { needs_redraw = true; }
+                                handlers::input::InputResult::UpdateRequested => {
+                                    return Ok(Some(42))
+                                }
+                                handlers::input::InputResult::Continue => {
+                                    needs_redraw = true;
+                                    continue;
+                                }
+                                handlers::input::InputResult::Ok => {
+                                    needs_redraw = true;
+                                }
                             }
                         }
                     }

--- a/src/matrix_rain.rs
+++ b/src/matrix_rain.rs
@@ -1,5 +1,6 @@
 // Matrix Rain Animation for FTUE
 use crate::app::{App, MatrixColumn};
+use rand::Rng;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -7,24 +8,19 @@ use ratatui::{
     widgets::{Clear, Paragraph, Wrap},
     Frame,
 };
-use rand::Rng;
 
 const MATRIX_CHARS: &[char] = &[
     // Safe ASCII / Width-1 characters to prevent layout breaks in Windows/Hyper
-    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
-    'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
-    'U', 'V', 'W', 'X', 'Y', 'Z',
-    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
-    'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
-    'u', 'v', 'w', 'x', 'y', 'z',
-    '@', '#', '$', '%', '&', '*', '+', '=', '<', '>',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I',
+    'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b',
+    'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u',
+    'v', 'w', 'x', 'y', 'z', '@', '#', '$', '%', '&', '*', '+', '=', '<', '>',
 ];
 
 pub fn init_matrix_rain(area: Rect) -> Vec<MatrixColumn> {
     let mut rng = rand::thread_rng();
     let mut columns = Vec::new();
-    
+
     // Logo boundaries for guaranteed density
     let logo_width = 103;
     let logo_x_start = area.width.saturating_sub(logo_width) / 2;
@@ -35,21 +31,21 @@ pub fn init_matrix_rain(area: Rect) -> Vec<MatrixColumn> {
         let is_logo_x = x >= logo_x_start && x < logo_x_end;
         // Boost density in logo area (multiple streams per column)
         let streams = if is_logo_x { 2 } else { 1 };
-        
+
         for _ in 0..streams {
             // Halved density: 0.90 -> 0.45
             // But KEEP logo area guaranteed (is_logo_x) so the logo still builds properly
-            if is_logo_x || rng.gen_bool(0.45) { 
+            if is_logo_x || rng.gen_bool(0.45) {
                 let length = rng.gen_range(10..40); // varied length
                 let speed = rng.gen_range(1..4); // Varied speed (1=fastest, 3=slower)
-                // Offset Y start to stagger particles in double streams
+                                                 // Offset Y start to stagger particles in double streams
                 let y = rng.gen_range(0..area.height + length);
-                
+
                 let mut chars = Vec::new();
                 for _ in 0..length {
                     chars.push(MATRIX_CHARS[rng.gen_range(0..MATRIX_CHARS.len())]);
                 }
-                
+
                 columns.push(MatrixColumn {
                     x,
                     y: y.saturating_sub(length), // Start offscreen or staggered
@@ -60,13 +56,19 @@ pub fn init_matrix_rain(area: Rect) -> Vec<MatrixColumn> {
             }
         }
     }
-    
+
     columns
 }
 
-pub fn update_matrix_rain(columns: &mut Vec<MatrixColumn>, area: Rect, tick: u64, logo_hits: &mut Vec<bool>, show_logo: bool) {
+pub fn update_matrix_rain(
+    columns: &mut [MatrixColumn],
+    area: Rect,
+    tick: u64,
+    logo_hits: &mut [bool],
+    show_logo: bool,
+) {
     let mut rng = rand::thread_rng();
-    
+
     let logo_width = 103;
     let logo_height = LOGO_LINES.len() as u16;
     let logo_x = area.x + area.width.saturating_sub(logo_width) / 2;
@@ -74,25 +76,24 @@ pub fn update_matrix_rain(columns: &mut Vec<MatrixColumn>, area: Rect, tick: u64
 
     for column in columns.iter_mut() {
         // Update position based on speed
-        if tick % column.speed as u64 == 0 {
+        if tick.is_multiple_of(column.speed as u64) {
             column.y += 1;
 
             // Hit detection for building logo: Check the head AND the immediate trail segment
-            if show_logo {
-                if column.x >= logo_x && column.x < logo_x + logo_width {
-                    let lx = (column.x - logo_x) as usize;
-                    // Check the head and a few pixels of the tail to "paint" the logo in more solidly
-                    for i in 0..6 { // Check top 6 chars of the falling column
-                        let py = column.y.saturating_sub(i);
-                        if py >= logo_y && py < logo_y + logo_height {
-                            let ly = (py - logo_y) as usize;
-                            if let Some(line) = LOGO_LINES.get(ly) {
-                                if let Some(c) = line.chars().nth(lx) {
-                                    if c != ' ' {
-                                        let idx = ly * (logo_width as usize) + lx;
-                                        if idx < logo_hits.len() {
-                                            logo_hits[idx] = true;
-                                        }
+            if show_logo && column.x >= logo_x && column.x < logo_x + logo_width {
+                let lx = (column.x - logo_x) as usize;
+                // Check the head and a few pixels of the tail to "paint" the logo in more solidly
+                for i in 0..6 {
+                    // Check top 6 chars of the falling column
+                    let py = column.y.saturating_sub(i);
+                    if py >= logo_y && py < logo_y + logo_height {
+                        let ly = (py - logo_y) as usize;
+                        if let Some(line) = LOGO_LINES.get(ly) {
+                            if let Some(c) = line.chars().nth(lx) {
+                                if c != ' ' {
+                                    let idx = ly * (logo_width as usize) + lx;
+                                    if idx < logo_hits.len() {
+                                        logo_hits[idx] = true;
                                     }
                                 }
                             }
@@ -100,21 +101,22 @@ pub fn update_matrix_rain(columns: &mut Vec<MatrixColumn>, area: Rect, tick: u64
                     }
                 }
             }
-            
+
             // Reset column if it goes off screen
             if column.y > area.height + column.length {
                 column.y = 0;
                 column.x = rng.gen_range(0..area.width);
-                
+
                 // Randomize chars
                 for i in 0..column.chars.len() {
                     column.chars[i] = MATRIX_CHARS[rng.gen_range(0..MATRIX_CHARS.len())];
                 }
             } else {
                 // Occasional "decryption" shift: change a random character in the column
-                if rng.gen_bool(0.05) { // 5% chance per frame per column
-                     let idx = rng.gen_range(0..column.chars.len());
-                     column.chars[idx] = MATRIX_CHARS[rng.gen_range(0..MATRIX_CHARS.len())];
+                if rng.gen_bool(0.05) {
+                    // 5% chance per frame per column
+                    let idx = rng.gen_range(0..column.chars.len());
+                    column.chars[idx] = MATRIX_CHARS[rng.gen_range(0..MATRIX_CHARS.len())];
                 }
             }
         }
@@ -134,7 +136,7 @@ pub fn render_matrix_rain(f: &mut Frame, app: &App, area: Rect) {
     // Clear background to hide UI completely (Startup and Screensaver)
     f.render_widget(Clear, area);
     let buf = f.buffer_mut();
-    
+
     // Fill background with black
     for y in area.top()..area.bottom() {
         for x in area.left()..area.right() {
@@ -150,7 +152,7 @@ pub fn render_matrix_rain(f: &mut Frame, app: &App, area: Rect) {
     let logo_height = LOGO_LINES.len() as u16;
     let logo_x = area.x + area.width.saturating_sub(logo_width) / 2;
     let logo_y = area.y + area.height.saturating_sub(logo_height) / 2;
-    
+
     // 1. Draw the "trace" (activated logo pixels)
     // This builds up the static logo as rain passes through it
     for ly in 0..logo_height {
@@ -159,14 +161,19 @@ pub fn render_matrix_rain(f: &mut Frame, app: &App, area: Rect) {
             if let Some(true) = app.matrix_rain_logo_hits.get(idx) {
                 let gx = logo_x + lx;
                 let gy = logo_y + ly;
-                
-                if gx >= area.left() && gx < area.right() && gy >= area.top() && gy < area.bottom() {
+
+                if gx >= area.left() && gx < area.right() && gy >= area.top() && gy < area.bottom()
+                {
                     if let Some(line) = LOGO_LINES.get(ly as usize) {
                         if let Some(c) = line.chars().nth(lx as usize) {
                             if c != ' ' {
                                 if let Some(cell) = buf.cell_mut((gx, gy)) {
                                     cell.set_char(c);
-                                    cell.set_style(Style::default().fg(crate::ui::colors::MATRIX_GREEN).add_modifier(Modifier::BOLD));
+                                    cell.set_style(
+                                        Style::default()
+                                            .fg(crate::ui::colors::MATRIX_GREEN)
+                                            .add_modifier(Modifier::BOLD),
+                                    );
                                 }
                             }
                         }
@@ -180,16 +187,16 @@ pub fn render_matrix_rain(f: &mut Frame, app: &App, area: Rect) {
     for (ly, line) in LOGO_LINES.iter().enumerate() {
         let gy = logo_y + ly as u16;
         if gy >= area.top() && gy < area.bottom() {
-            let trace_style = Style::default().fg(Color::Rgb(0, 40, 0)); 
+            let trace_style = Style::default().fg(Color::Rgb(0, 40, 0));
             for (lx, c) in line.chars().enumerate() {
                 let gx = logo_x + lx as u16;
                 if gx >= area.left() && gx < area.right() && c != ' ' {
                     if let Some(cell) = buf.cell_mut((gx, gy)) {
                         // Only draw ghosting if not already hit
-                        let idx = (ly as usize) * (logo_width as usize) + lx;
+                        let idx = ly * (logo_width as usize) + lx;
                         if app.matrix_rain_logo_hits.get(idx) != Some(&true) {
-                           cell.set_char(c);
-                           cell.set_style(trace_style);
+                            cell.set_char(c);
+                            cell.set_style(trace_style);
                         }
                     }
                 }
@@ -201,7 +208,9 @@ pub fn render_matrix_rain(f: &mut Frame, app: &App, area: Rect) {
     let mut rng = rand::thread_rng();
     for column in &app.matrix_rain_columns {
         let gx = area.x + column.x;
-        if gx < area.left() || gx >= area.right() { continue; }
+        if gx < area.left() || gx >= area.right() {
+            continue;
+        }
 
         for (i, &ch) in column.chars.iter().enumerate() {
             let y = column.y.saturating_sub(i as u16);
@@ -210,8 +219,10 @@ pub fn render_matrix_rain(f: &mut Frame, app: &App, area: Rect) {
             if gy >= area.top() && gy < area.bottom() {
                 // Check if this rain character overlaps with a logo character
                 let mut logo_char = None;
-                if gx >= logo_x && gx < logo_x + logo_width &&
-                   gy >= logo_y && gy < logo_y + logo_height
+                if gx >= logo_x
+                    && gx < logo_x + logo_width
+                    && gy >= logo_y
+                    && gy < logo_y + logo_height
                 {
                     let lx = (gx - logo_x) as usize;
                     let ly = (gy - logo_y) as usize;
@@ -227,7 +238,7 @@ pub fn render_matrix_rain(f: &mut Frame, app: &App, area: Rect) {
                 let is_glitch = rng.gen_bool(0.01);
                 let (draw_ch, style) = if let Some(lc) = logo_char {
                     let color = if i == 0 {
-                        Color::White 
+                        Color::White
                     } else if i < 15 {
                         Color::Rgb(180, 255, 180)
                     } else {
@@ -236,7 +247,7 @@ pub fn render_matrix_rain(f: &mut Frame, app: &App, area: Rect) {
                     (lc, Style::default().fg(color).add_modifier(Modifier::BOLD))
                 } else {
                     let color = if i == 0 || is_glitch {
-                        Color::White 
+                        Color::White
                     } else if i < 6 {
                         Color::Rgb(150, 255, 150)
                     } else {
@@ -244,7 +255,7 @@ pub fn render_matrix_rain(f: &mut Frame, app: &App, area: Rect) {
                     };
                     (ch, Style::default().fg(color).add_modifier(Modifier::BOLD))
                 };
-                
+
                 if let Some(cell) = buf.cell_mut((gx, gy)) {
                     cell.set_char(draw_ch);
                     cell.set_style(style);
@@ -256,16 +267,22 @@ pub fn render_matrix_rain(f: &mut Frame, app: &App, area: Rect) {
 
 pub fn render_welcome_popup(f: &mut Frame, app: &App, area: Rect) {
     let popup_area = centered_rect(70, 60, area);
-    
+
     f.render_widget(Clear, popup_area);
-    
-    let inner = crate::ui::common::render_composite_block(f, popup_area, Some(" // SYSTEM_INITIALIZATION // "));
-    
+
+    let inner = crate::ui::common::render_composite_block(
+        f,
+        popup_area,
+        Some(" // SYSTEM_INITIALIZATION // "),
+    );
+
     let mut text = vec![
         Line::from(""),
         Line::from(Span::styled(
             "WELCOME TO MATRIX IPTV",
-            Style::default().fg(crate::ui::colors::MATRIX_GREEN).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(crate::ui::colors::MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         Line::from(Span::styled(
@@ -275,41 +292,59 @@ pub fn render_welcome_popup(f: &mut Frame, app: &App, area: Rect) {
         Line::from(""),
         Line::from(""),
     ];
-    
+
     // Only show "GETTING STARTED" if user has no playlists
     if app.config.accounts.is_empty() {
         text.extend(vec![
             Line::from(Span::styled(
                 "⚠ GETTING STARTED:",
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
             )),
             Line::from(""),
             Line::from(vec![
                 Span::styled("1. ", Style::default().fg(Color::White)),
                 Span::styled("Press ", Style::default().fg(Color::White)),
-                Span::styled("[n]", Style::default().fg(crate::ui::colors::MATRIX_GREEN).add_modifier(Modifier::BOLD)),
-                Span::styled(" to add your first IPTV playlist", Style::default().fg(Color::White)),
+                Span::styled(
+                    "[n]",
+                    Style::default()
+                        .fg(crate::ui::colors::MATRIX_GREEN)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    " to add your first IPTV playlist",
+                    Style::default().fg(Color::White),
+                ),
             ]),
             Line::from(""),
             Line::from(vec![
                 Span::styled("2. ", Style::default().fg(Color::White)),
-                Span::styled("Enter your Xtream Codes credentials", Style::default().fg(Color::White)),
+                Span::styled(
+                    "Enter your Xtream Codes credentials",
+                    Style::default().fg(Color::White),
+                ),
             ]),
             Line::from(""),
             Line::from(vec![
                 Span::styled("3. ", Style::default().fg(Color::White)),
-                Span::styled("Start watching Live TV, Movies, and Series!", Style::default().fg(Color::White)),
+                Span::styled(
+                    "Start watching Live TV, Movies, and Series!",
+                    Style::default().fg(Color::White),
+                ),
             ]),
             Line::from(""),
             Line::from(""),
         ]);
     }
-    
+
     // Always show disclaimer
     text.extend(vec![
         Line::from(Span::styled(
             "⚠ DISCLAIMER:",
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         )),
         Line::from(Span::styled(
             "This app does not provide any content. You must have",
@@ -323,14 +358,16 @@ pub fn render_welcome_popup(f: &mut Frame, app: &App, area: Rect) {
         Line::from(""),
         Line::from(Span::styled(
             "Press any key to continue...",
-            Style::default().fg(crate::ui::colors::MATRIX_GREEN).add_modifier(Modifier::ITALIC),
+            Style::default()
+                .fg(crate::ui::colors::MATRIX_GREEN)
+                .add_modifier(Modifier::ITALIC),
         )),
     ]);
-    
+
     let paragraph = Paragraph::new(text)
         .alignment(Alignment::Center)
         .wrap(Wrap { trim: true });
-    
+
     f.render_widget(paragraph, inner);
 }
 

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -1,3 +1,5 @@
+use crate::api::{IptvClient, XtreamClient};
+use crate::config::{Account, AccountType, CategorySortOrder};
 use ratatui::{
     backend::Backend,
     crossterm::event::{self, Event, KeyCode, KeyEventKind},
@@ -7,13 +9,14 @@ use ratatui::{
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
     Frame, Terminal,
 };
-use crate::api::{IptvClient, XtreamClient};
-use crate::config::{Account, AccountType, CategorySortOrder};
 use std::collections::HashSet;
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
 use std::time::Duration;
-use tachyonfx::{Effect, fx};
+use tachyonfx::{fx, Effect};
+
+type ValidationResult = Result<(String, String, String, String), String>;
+type ValidationReceiver = Receiver<ValidationResult>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OnboardingStep {
@@ -38,7 +41,7 @@ pub struct OnboardingState {
     pub active_effect: Option<Effect>,
     pub should_quit: bool,
     pub success_account: Option<Account>,
-    pub validation_rx: Option<Receiver<Result<(String, String, String, String), String>>>,
+    pub validation_rx: Option<ValidationReceiver>,
 }
 
 impl Default for OnboardingState {
@@ -61,24 +64,26 @@ impl Default for OnboardingState {
     }
 }
 
-pub fn run_onboarding<B: Backend>(terminal: &mut Terminal<B>) -> anyhow::Result<Option<Account>> 
-where 
-    <B as Backend>::Error: std::fmt::Display + std::fmt::Debug + Send + Sync + 'static
+pub fn run_onboarding<B: Backend>(terminal: &mut Terminal<B>) -> anyhow::Result<Option<Account>>
+where
+    <B as Backend>::Error: std::fmt::Display + std::fmt::Debug + Send + Sync + 'static,
 {
     let mut state = OnboardingState::default();
     let tick_rate = Duration::from_millis(16); // 60fps for smooth animations
 
     loop {
-        terminal.draw(|f| ui(f, &mut state)).map_err(|e| anyhow::anyhow!(e))?;
+        terminal
+            .draw(|f| ui(f, &mut state))
+            .map_err(|e| anyhow::anyhow!(e))?;
 
         if state.should_quit {
             return Ok(None);
         }
-        
+
         if let Some(_account) = state.success_account.clone() {
             // Need a slight pause for completion state to be seen
             if state.step == OnboardingStep::Success {
-                 // Wait for user to press enter in handle_key
+                // Wait for user to press enter in handle_key
             }
         }
 
@@ -102,7 +107,11 @@ where
                     match result {
                         Ok((url, username, password, name)) => {
                             state.success_account = Some(Account {
-                                name: if name.is_empty() { "My Playlist".to_string() } else { name },
+                                name: if name.is_empty() {
+                                    "My Playlist".to_string()
+                                } else {
+                                    name
+                                },
                                 base_url: url,
                                 username,
                                 password,
@@ -131,23 +140,19 @@ where
 
 fn handle_key(state: &mut OnboardingState, key: KeyCode) {
     match state.step {
-        OnboardingStep::Welcome => {
-            match key {
-                KeyCode::Enter => transition_to(state, OnboardingStep::HowToGet),
-                KeyCode::Esc => state.should_quit = true,
-                _ => {}
+        OnboardingStep::Welcome => match key {
+            KeyCode::Enter => transition_to(state, OnboardingStep::HowToGet),
+            KeyCode::Esc => state.should_quit = true,
+            _ => {}
+        },
+        OnboardingStep::HowToGet => match key {
+            KeyCode::Esc | KeyCode::Left => transition_to(state, OnboardingStep::Welcome),
+            KeyCode::Enter | KeyCode::Right => transition_to(state, OnboardingStep::Credentials),
+            KeyCode::Char('o') | KeyCode::Char('O') => {
+                let _ = webbrowser::open("https://g2g.to/iptv");
             }
-        }
-        OnboardingStep::HowToGet => {
-            match key {
-                KeyCode::Esc | KeyCode::Left => transition_to(state, OnboardingStep::Welcome),
-                KeyCode::Enter | KeyCode::Right => transition_to(state, OnboardingStep::Credentials),
-                KeyCode::Char('o') | KeyCode::Char('O') => {
-                    let _ = webbrowser::open("https://g2g.to/iptv");
-                },
-                _ => {}
-            }
-        }
+            _ => {}
+        },
         OnboardingStep::Credentials => {
             match key {
                 KeyCode::Esc => transition_to(state, OnboardingStep::HowToGet),
@@ -174,29 +179,36 @@ fn handle_key(state: &mut OnboardingState, key: KeyCode) {
                     state.show_password = !state.show_password;
                 }
                 KeyCode::Enter => {
-                    if state.input_url.is_empty() || state.input_username.is_empty() || state.input_password.is_empty() {
+                    if state.input_url.is_empty()
+                        || state.input_username.is_empty()
+                        || state.input_password.is_empty()
+                    {
                         state.error_msg = Some("Please fill in all fields".to_string());
                     } else {
                         state.error_msg = None;
                         state.spinner_frame = 0;
                         state.step = OnboardingStep::Validating;
-                        
+
                         // Trigger real validation task
                         let url = state.input_url.clone();
                         let username = state.input_username.clone();
                         let password = state.input_password.clone();
                         let name = state.input_name.clone();
-                    
+
                         let (tx, rx) = mpsc::channel();
                         state.validation_rx = Some(rx);
-                        
+
                         thread::spawn(move || {
                             let rt = tokio::runtime::Builder::new_current_thread()
                                 .enable_all()
                                 .build()
                                 .unwrap();
                             rt.block_on(async {
-                                let client = IptvClient::Xtream(XtreamClient::new(url.clone(), username.clone(), password.clone()));
+                                let client = IptvClient::Xtream(XtreamClient::new(
+                                    url.clone(),
+                                    username.clone(),
+                                    password.clone(),
+                                ));
                                 match client.authenticate().await {
                                     Ok((true, _, _, _)) => {
                                         let _ = tx.send(Ok((url, username, password, name)));
@@ -228,12 +240,10 @@ fn handle_key(state: &mut OnboardingState, key: KeyCode) {
             }
         }
         OnboardingStep::Validating => {}
-        OnboardingStep::Failed => {
-            match key {
-                KeyCode::Esc | KeyCode::Enter => transition_to(state, OnboardingStep::Credentials),
-                _ => {}
-            }
-        }
+        OnboardingStep::Failed => match key {
+            KeyCode::Esc | KeyCode::Enter => transition_to(state, OnboardingStep::Credentials),
+            _ => {}
+        },
         OnboardingStep::Success => {}
     }
 }
@@ -256,16 +266,15 @@ fn transition_to(state: &mut OnboardingState, next_step: OnboardingStep) {
 fn ui(f: &mut Frame, state: &mut OnboardingState) {
     let area = f.area();
     f.render_widget(Clear, f.area());
-    
+
     // Explicit background fill to prevent terminal "gray" artifacting
     f.render_widget(
-        ratatui::widgets::Block::default()
-            .bg(ratatui::style::Color::Rgb(0, 0, 0)),
-        f.area()
+        ratatui::widgets::Block::default().bg(ratatui::style::Color::Rgb(0, 0, 0)),
+        f.area(),
     );
 
     let content_area = centered_rect(70, 70, area);
-    
+
     match state.step {
         OnboardingStep::Welcome => render_welcome(f, state, content_area),
         OnboardingStep::HowToGet => render_how_to_get(f, state, content_area),
@@ -283,7 +292,12 @@ fn render_welcome(f: &mut Frame, _state: &OnboardingState, area: Rect) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(crate::ui::colors::SOFT_GREEN))
         .border_type(ratatui::widgets::BorderType::Rounded)
-        .title(Span::styled(" MATRIX IPTV ONBOARDING ", Style::default().fg(crate::ui::colors::MATRIX_GREEN).add_modifier(Modifier::BOLD)))
+        .title(Span::styled(
+            " MATRIX IPTV ONBOARDING ",
+            Style::default()
+                .fg(crate::ui::colors::MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ))
         .title_alignment(Alignment::Center);
 
     let inner = block.inner(area);
@@ -300,16 +314,22 @@ fn render_welcome(f: &mut Frame, _state: &OnboardingState, area: Rect) {
 
     let text = vec![
         Line::from(""),
-        Line::from(Span::styled(ascii_logo, Style::default().fg(crate::ui::colors::MATRIX_GREEN))),
+        Line::from(Span::styled(
+            ascii_logo,
+            Style::default().fg(crate::ui::colors::MATRIX_GREEN),
+        )),
         Line::from(""),
         Line::from("Welcome to Matrix IPTV!").alignment(Alignment::Center),
         Line::from("The ultimate TUI for your streaming needs.").alignment(Alignment::Center),
         Line::from(""),
         Line::from("You don't have any playlists configured yet.").alignment(Alignment::Center),
         Line::from(""),
-        Line::from(Span::styled("Press [Enter] to begin setup", Style::default().fg(crate::ui::colors::TEXT_SECONDARY))),
+        Line::from(Span::styled(
+            "Press [Enter] to begin setup",
+            Style::default().fg(crate::ui::colors::TEXT_SECONDARY),
+        )),
     ];
-    
+
     let p = Paragraph::new(text).alignment(Alignment::Center);
     f.render_widget(p, inner);
 }
@@ -319,7 +339,12 @@ fn render_how_to_get(f: &mut Frame, _state: &OnboardingState, area: Rect) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(crate::ui::colors::SOFT_GREEN))
         .border_type(ratatui::widgets::BorderType::Rounded)
-        .title(Span::styled(" STEP 1: GET A PLAYLIST ", Style::default().fg(crate::ui::colors::MATRIX_GREEN).add_modifier(Modifier::BOLD)))
+        .title(Span::styled(
+            " STEP 1: GET A PLAYLIST ",
+            Style::default()
+                .fg(crate::ui::colors::MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ))
         .title_alignment(Alignment::Center);
 
     let inner = block.inner(area);
@@ -327,7 +352,10 @@ fn render_how_to_get(f: &mut Frame, _state: &OnboardingState, area: Rect) {
 
     let text = vec![
         Line::from(""),
-        Line::from(Span::styled("Matrix IPTV is a player. You need a provider.", Style::default().add_modifier(Modifier::BOLD))),
+        Line::from(Span::styled(
+            "Matrix IPTV is a player. You need a provider.",
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
         Line::from(""),
         Line::from("If you don't have one, search online for IPTV providers."),
         Line::from("Popular sources: G2G, Z2U, eBay."),
@@ -336,16 +364,26 @@ fn render_how_to_get(f: &mut Frame, _state: &OnboardingState, area: Rect) {
         Line::from("Look for \"Xtream Codes\" format credentials:"),
         Line::from("URL, Username, and Password."),
         Line::from(""),
-        Line::from(Span::styled("Press [O] to open search in browser", Style::default().fg(crate::ui::colors::TEXT_SECONDARY))),
+        Line::from(Span::styled(
+            "Press [O] to open search in browser",
+            Style::default().fg(crate::ui::colors::TEXT_SECONDARY),
+        )),
         Line::from(""),
         Line::from(vec![
-            Span::styled("Press [Enter] to continue", Style::default().fg(crate::ui::colors::MATRIX_GREEN).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "Press [Enter] to continue",
+                Style::default()
+                    .fg(crate::ui::colors::MATRIX_GREEN)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" | ", Style::default().fg(Color::DarkGray)),
             Span::styled("[Esc] Go Back", Style::default().fg(Color::Gray)),
         ]),
     ];
-    
-    let p = Paragraph::new(text).alignment(Alignment::Center).wrap(Wrap { trim: false });
+
+    let p = Paragraph::new(text)
+        .alignment(Alignment::Center)
+        .wrap(Wrap { trim: false });
     f.render_widget(p, inner);
 }
 
@@ -354,7 +392,12 @@ fn render_credentials(f: &mut Frame, state: &OnboardingState, area: Rect) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(crate::ui::colors::SOFT_GREEN))
         .border_type(ratatui::widgets::BorderType::Rounded)
-        .title(Span::styled(" STEP 2: ENTER CREDENTIALS ", Style::default().fg(crate::ui::colors::MATRIX_GREEN).add_modifier(Modifier::BOLD)))
+        .title(Span::styled(
+            " STEP 2: ENTER CREDENTIALS ",
+            Style::default()
+                .fg(crate::ui::colors::MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ))
         .title_alignment(Alignment::Center);
 
     let inner = block.inner(area);
@@ -372,56 +415,104 @@ fn render_credentials(f: &mut Frame, state: &OnboardingState, area: Rect) {
         ])
         .split(inner);
 
-    let active_style = Style::default().fg(crate::ui::colors::MATRIX_GREEN).add_modifier(Modifier::BOLD);
+    let active_style = Style::default()
+        .fg(crate::ui::colors::MATRIX_GREEN)
+        .add_modifier(Modifier::BOLD);
     let inactive_style = Style::default().fg(Color::DarkGray);
 
     // Name
     f.render_widget(
-        Paragraph::new(state.input_name.as_str())
-            .block(Block::default().borders(Borders::ALL).title(" Playlist Name (Optional) ").border_style(if state.active_field==0 {active_style} else {inactive_style})),
-        chunks[0]
+        Paragraph::new(state.input_name.as_str()).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Playlist Name (Optional) ")
+                .border_style(if state.active_field == 0 {
+                    active_style
+                } else {
+                    inactive_style
+                }),
+        ),
+        chunks[0],
     );
 
     // URL
     f.render_widget(
-        Paragraph::new(state.input_url.as_str())
-            .block(Block::default().borders(Borders::ALL).title(" Server URL (http://...) ").border_style(if state.active_field==1 {active_style} else {inactive_style})),
-        chunks[1]
+        Paragraph::new(state.input_url.as_str()).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Server URL (http://...) ")
+                .border_style(if state.active_field == 1 {
+                    active_style
+                } else {
+                    inactive_style
+                }),
+        ),
+        chunks[1],
     );
 
     // User
     f.render_widget(
-        Paragraph::new(state.input_username.as_str())
-            .block(Block::default().borders(Borders::ALL).title(" Username ").border_style(if state.active_field==2 {active_style} else {inactive_style})),
-        chunks[2]
+        Paragraph::new(state.input_username.as_str()).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Username ")
+                .border_style(if state.active_field == 2 {
+                    active_style
+                } else {
+                    inactive_style
+                }),
+        ),
+        chunks[2],
     );
 
     // Pass
-    let pass_display = if state.show_password { state.input_password.clone() } else { "*".repeat(state.input_password.len()) };
+    let pass_display = if state.show_password {
+        state.input_password.clone()
+    } else {
+        "*".repeat(state.input_password.len())
+    };
     f.render_widget(
-        Paragraph::new(pass_display)
-            .block(Block::default().borders(Borders::ALL).title(" Password ").border_style(if state.active_field==3 {active_style} else {inactive_style})),
-        chunks[3]
+        Paragraph::new(pass_display).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Password ")
+                .border_style(if state.active_field == 3 {
+                    active_style
+                } else {
+                    inactive_style
+                }),
+        ),
+        chunks[3],
     );
 
     // Hints & Error
-    let mut hints = vec![
-        Line::from(vec![
-            Span::styled("[Tab]", Style::default().add_modifier(Modifier::BOLD)),
-            Span::raw(" Move   "),
-            Span::styled("[T]", Style::default().add_modifier(Modifier::BOLD)),
-            Span::raw(" Toggle Pass (at field)   "),
-            Span::styled("[Enter]", Style::default().add_modifier(Modifier::BOLD)),
-            Span::styled(" Connect", Style::default().fg(crate::ui::colors::MATRIX_GREEN)),
-        ])
-    ];
+    let mut hints = vec![Line::from(vec![
+        Span::styled("[Tab]", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" Move   "),
+        Span::styled("[T]", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" Toggle Pass (at field)   "),
+        Span::styled("[Enter]", Style::default().add_modifier(Modifier::BOLD)),
+        Span::styled(
+            " Connect",
+            Style::default().fg(crate::ui::colors::MATRIX_GREEN),
+        ),
+    ])];
 
     if let Some(err) = &state.error_msg {
         hints.push(Line::from(""));
-        hints.push(Line::from(Span::styled(format!(" ERROR: {} ", err), Style::default().bg(Color::Red).fg(Color::White).add_modifier(Modifier::BOLD))));
+        hints.push(Line::from(Span::styled(
+            format!(" ERROR: {} ", err),
+            Style::default()
+                .bg(Color::Red)
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        )));
     }
 
-    f.render_widget(Paragraph::new(hints).alignment(Alignment::Center), chunks[4]);
+    f.render_widget(
+        Paragraph::new(hints).alignment(Alignment::Center),
+        chunks[4],
+    );
 }
 
 fn render_validating(f: &mut Frame, state: &OnboardingState, area: Rect) {
@@ -430,7 +521,7 @@ fn render_validating(f: &mut Frame, state: &OnboardingState, area: Rect) {
         .border_style(Style::default().fg(crate::ui::colors::MATRIX_GREEN))
         .border_type(ratatui::widgets::BorderType::Rounded)
         .title(" CONNECTING ");
-    
+
     let inner = block.inner(area);
     f.render_widget(block, area);
 
@@ -439,7 +530,10 @@ fn render_validating(f: &mut Frame, state: &OnboardingState, area: Rect) {
 
     let text = vec![
         Line::from(""),
-        Line::from(Span::styled(format!("{} Validating Server Connection...", spinner), Style::default().fg(crate::ui::colors::MATRIX_GREEN))),
+        Line::from(Span::styled(
+            format!("{} Validating Server Connection...", spinner),
+            Style::default().fg(crate::ui::colors::MATRIX_GREEN),
+        )),
         Line::from(""),
         Line::from("Checking credentials and downloading basics..."),
     ];
@@ -453,17 +547,23 @@ fn render_failed(f: &mut Frame, state: &OnboardingState, area: Rect) {
         .border_style(Style::default().fg(Color::Red))
         .border_type(ratatui::widgets::BorderType::Rounded)
         .title(" CONNECTION FAILED ");
-    
+
     let inner = block.inner(area);
     f.render_widget(block, area);
 
     let text = vec![
         Line::from(""),
-        Line::from(Span::styled("X Failed to authenticate with the server.", Style::default().fg(Color::Red))),
+        Line::from(Span::styled(
+            "X Failed to authenticate with the server.",
+            Style::default().fg(Color::Red),
+        )),
         Line::from(""),
         Line::from(state.error_msg.as_deref().unwrap_or("Unknown error")),
         Line::from(""),
-        Line::from(Span::styled("Press [Enter] to try again", Style::default().add_modifier(Modifier::BOLD))),
+        Line::from(Span::styled(
+            "Press [Enter] to try again",
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
     ];
 
     f.render_widget(Paragraph::new(text).alignment(Alignment::Center), inner);
@@ -475,18 +575,28 @@ fn render_success(f: &mut Frame, _state: &OnboardingState, area: Rect) {
         .border_style(Style::default().fg(crate::ui::colors::MATRIX_GREEN))
         .border_type(ratatui::widgets::BorderType::Rounded)
         .title(" SUCCESS ");
-    
+
     let inner = block.inner(area);
     f.render_widget(block, area);
 
     let text = vec![
         Line::from(""),
-        Line::from(Span::styled("✓ Connected successfully!", Style::default().fg(crate::ui::colors::MATRIX_GREEN).add_modifier(Modifier::BOLD))),
+        Line::from(Span::styled(
+            "✓ Connected successfully!",
+            Style::default()
+                .fg(crate::ui::colors::MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        )),
         Line::from(""),
         Line::from("Your first playlist has been configured."),
         Line::from("Welcome to the Matrix."),
         Line::from(""),
-        Line::from(Span::styled("Press [Enter] to start", Style::default().fg(crate::ui::colors::MATRIX_GREEN).add_modifier(Modifier::BOLD))),
+        Line::from(Span::styled(
+            "Press [Enter] to start",
+            Style::default()
+                .fg(crate::ui::colors::MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        )),
     ];
 
     f.render_widget(Paragraph::new(text).alignment(Alignment::Center), inner);
@@ -499,8 +609,11 @@ fn render_footer(f: &mut Frame, state: &OnboardingState, area: Rect) {
         OnboardingStep::Credentials | OnboardingStep::Validating | OnboardingStep::Failed => 3,
         OnboardingStep::Success => 4,
     };
-    let dots = (1..=4).map(|i| if i == current { "●" } else { "○" }).collect::<Vec<_>>().join(" ");
-    
+    let dots = (1..=4)
+        .map(|i| if i == current { "●" } else { "○" })
+        .collect::<Vec<_>>()
+        .join(" ");
+
     let footer_text = format!(" Step {} of 4  {} ", current, dots);
     let area = Rect {
         x: area.x,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -961,7 +961,7 @@ pub fn parse_category(name: &str) -> ParsedCategory {
         let upper_c = cleaned.to_uppercase();
         if upper_c.ends_with(s) {
             cleaned = cleaned[..cleaned.len() - s.len()].trim().to_string();
-        } else if upper_c.starts_with(s) {
+        } else if s != "PPV" && upper_c.starts_with(s) {
             cleaned = cleaned[s.len()..].trim().to_string();
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -504,10 +504,57 @@ pub fn country_flag(country: &str) -> &'static str {
 static GENERIC_COUNTRY_PREFIX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"(?i)^([A-Z]{1,3})\s*[|:]").unwrap());
 
+static LIVE_PREFIX_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)^([A-Z]{1,3})(\s*[|:]\s*|\s+)").unwrap());
+
+fn has_strong_us_marker(name_upper: &str) -> bool {
+    name_upper.contains("USA")
+        || name_upper.contains("US LOCALS")
+        || name_upper.contains("AMERICA")
+        || name_upper.contains("UNITED STATES")
+        || name_upper.starts_with("US ")
+        || name_upper.starts_with("US|")
+        || name_upper.starts_with("US:")
+        || name_upper.starts_with("US-")
+        || name_upper.starts_with("AM ")
+        || name_upper.starts_with("AM|")
+        || name_upper.starts_with("AM:")
+        || name_upper.starts_with("AM-")
+}
+
+fn has_american_live_category_marker(name_upper: &str) -> bool {
+    [
+        "NFL",
+        "NBA",
+        "MLB",
+        "NHL",
+        "NCAA",
+        "MLS",
+        "ESPN",
+        "BALLY",
+        "YES NETWORK",
+        "MSG",
+        "ABC",
+        "NBC",
+        "CBS",
+        "FOX",
+        "PPV",
+        "UFC",
+        "24/7",
+        "24-7",
+        "24 7",
+        "24HR",
+        "24 HOUR",
+    ]
+    .iter()
+    .any(|&k| name_upper.contains(k))
+}
+
 /// Check if a name/category is American live content
 pub fn is_american_live(name: &str) -> bool {
     // Normalize special separators first
     let n = name.to_uppercase().replace("▎", "|").replace("︳", "|");
+    let has_us_marker = has_strong_us_marker(&n);
 
     // 0. Strict Blocker for known international junk that slips through (e.g. "AR|")
     // This handles cases where a prefix like Arabic (AR) is used without a space.
@@ -515,7 +562,32 @@ pub fn is_american_live(name: &str) -> bool {
         || n.starts_with("AR|")
         || n.starts_with("AR :")
         || n.starts_with("AR:"))
-        && !n.contains("USA")
+        && !has_us_marker
+    {
+        return false;
+    }
+
+    if let Some(caps) = LIVE_PREFIX_REGEX.captures(&n) {
+        if let Some(prefix) = caps.get(1) {
+            let p = prefix.as_str();
+            let separator = caps.get(2).map(|m| m.as_str()).unwrap_or_default();
+            let ambiguous_word_prefix = matches!(p, "AM" | "IN");
+            let foreign_live_prefix =
+                FOREIGN_COUNTRY_CODES.contains(p) || matches!(p, "CA" | "GB" | "UK");
+            if foreign_live_prefix
+                && !has_us_marker
+                && (separator.contains('|') || separator.contains(':') || !ambiguous_word_prefix)
+            {
+                return false;
+            }
+        }
+    }
+
+    if !has_us_marker
+        && (n.contains("CANADA")
+            || n.contains("CANADIAN")
+            || n.contains("UNITED KINGDOM")
+            || n.contains("BRITISH"))
     {
         return false;
     }
@@ -535,11 +607,7 @@ pub fn is_american_live(name: &str) -> bool {
             if !allowed_prefixes.contains(&p) {
                 // It has a prefix like "UK", "CA", "FR".
                 // We block it UNLESS it explicitly mentions USA inside the name.
-                if !n.contains("USA")
-                    && !n.contains("US LOCALS")
-                    && !n.contains("AMERICA")
-                    && !n.contains("UNITED STATES")
-                {
+                if !has_us_marker {
                     return false;
                 }
             }
@@ -548,7 +616,7 @@ pub fn is_american_live(name: &str) -> bool {
 
     // 2. Explicit Positive check
     // If it passed the prefix check (or has no prefix), we check if it's definitively American.
-    let positive_keywords = [
+    let strong_positive_keywords = [
         "USA",
         "U.S.A",
         " US ",
@@ -559,38 +627,22 @@ pub fn is_american_live(name: &str) -> bool {
         "UNITED STATES",
         "LOCAL",
         "LOCALS",
-        "NFL",
-        "NBA",
-        "MLB",
-        "NHL",
-        "NCAA",
-        "ESPN",
-        "BALLY",
-        "YES NETWORK",
-        "MSG",
-        "ABC",
-        "NBC",
-        "CBS",
-        "FOX",
         "4K",
         "UHD",
         "FHD",
         "VIP",
-        "PPV",
-        "UFC",
     ];
-    if positive_keywords.iter().any(|&k| n.contains(k))
-        || n.starts_with("US ")
-        || n.starts_with("US|")
-        || n.starts_with("US:")
-        || n.starts_with("US-")
-    {
+    if strong_positive_keywords.iter().any(|&k| n.contains(k)) || has_us_marker {
         return true;
     }
 
     // Use O(1) HashSet lookup instead of mega-regex
     if matches_foreign(&n) {
         return false;
+    }
+
+    if has_american_live_category_marker(&n) {
+        return true;
     }
 
     // Default: Allow everything else (Exclusion-based filtering)
@@ -810,10 +862,21 @@ pub fn parse_category(name: &str) -> ParsedCategory {
                 country = Some(code.to_string());
             }
 
-            if let Some(pos) = display_name.find(|c| c == '|' || c == ':' || c == '-') {
-                display_name = display_name[pos + 1..].trim().to_string();
-            } else if let Some(pos) = display_name.find(' ') {
-                display_name = display_name[pos + 1..].trim().to_string();
+            // Only strip if it's NOT a major league/sports marker OR if it has a real separator
+            let is_league = [
+                "NBA", "NFL", "MLB", "NHL", "UFC", "MLS", "NCAAF", "NCAAB", "PPV",
+            ]
+            .contains(&code);
+            let has_separator = display_name
+                .find(|c| c == '|' || c == ':' || c == '-')
+                .is_some();
+
+            if !is_league || has_separator {
+                if let Some(pos) = display_name.find(|c| c == '|' || c == ':' || c == '-') {
+                    display_name = display_name[pos + 1..].trim().to_string();
+                } else if let Some(pos) = display_name.find(' ') {
+                    display_name = display_name[pos + 1..].trim().to_string();
+                }
             }
 
             // Handle case where we still have a ▎ separator after prefix handling
@@ -847,6 +910,7 @@ pub fn parse_category(name: &str) -> ParsedCategory {
 
     // Detect quality
     let upper = display_name.to_uppercase();
+    let original_upper = original.to_uppercase();
     if upper.contains("4K")
         || upper.contains("ᵁᴴᴰ")
         || upper.contains("³⁸⁴⁰")
@@ -862,7 +926,9 @@ pub fn parse_category(name: &str) -> ParsedCategory {
     }
 
     // Detect content type
-    if upper.contains("SPORT")
+    if original_upper.contains("PPV") || upper.contains("PPV") {
+        content_type = Some(ContentType::PPV);
+    } else if upper.contains("SPORT")
         || ["NBA", "NFL", "MLB", "NHL", "UFC", "F1"]
             .iter()
             .any(|s| upper.contains(s))
@@ -1834,6 +1900,41 @@ mod tests {
         assert_eq!(parsed.country, Some("US".to_string()));
         assert_eq!(parsed.display_name, "SPORTS NETWORK");
         assert_eq!(parsed.content_type, Some(ContentType::Sports));
+    }
+
+    #[test]
+    fn test_merica_live_category_filter_markers() {
+        assert!(is_american_live("NBA Package"));
+        assert!(is_american_live("NBA League Pass"));
+        assert!(is_american_live("NHL Real"));
+        assert!(is_american_live("PPV Events"));
+        assert!(is_american_live("24/7 Channels"));
+        assert!(is_american_live("US | 24/7 ABC"));
+        assert!(is_american_live("AM | 24/7 ABC"));
+        assert!(is_american_live("IN Demand PPV"));
+
+        assert!(!is_american_live("UK PPV"));
+        assert!(!is_american_live("CA 24/7"));
+        assert!(!is_american_live("IN | 24/7 Cricket"));
+        assert!(!is_american_live("International PPV"));
+    }
+
+    #[test]
+    fn test_parse_nba_and_ppv_categories_as_categories() {
+        let nba = parse_category("NBA Package");
+        assert_eq!(nba.country, Some("NBA".to_string()));
+        assert_eq!(nba.display_name, "NBA Package");
+        assert_eq!(nba.content_type, Some(ContentType::Sports));
+
+        let ppv = parse_category("PPV Events");
+        assert_eq!(ppv.country, Some("PPV".to_string()));
+        assert_eq!(ppv.display_name, "PPV Events");
+        assert_eq!(ppv.content_type, Some(ContentType::PPV));
+
+        let ppv_event = parse_category("PPV | UFC 300");
+        assert_eq!(ppv_event.country, Some("PPV".to_string()));
+        assert_eq!(ppv_event.display_name, "UFC 300");
+        assert_eq!(ppv_event.content_type, Some(ContentType::PPV));
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -282,8 +282,7 @@ fn matches_foreign(name_upper: &str) -> bool {
     // 2. Country code structural match (e.g., "AR |", "|AR|", " AR ")
     for code in FOREIGN_COUNTRY_CODES.iter() {
         // "XX |" or "XX|" prefix
-        if name_upper.starts_with(code) {
-            let rest = &name_upper[code.len()..];
+        if let Some(rest) = name_upper.strip_prefix(code) {
             if rest.starts_with(" |")
                 || rest.starts_with("|")
                 || rest.starts_with(" :")
@@ -366,6 +365,14 @@ static CLEAN_SUFFIXES: Lazy<Regex> = Lazy::new(|| {
 static CLEAN_BRACKETS_GARBAGE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"(?i)\s*[\(\[]\s*(?:ET|UK|BST|CET|MEZ|EST|EDT|PT|PST|PDT|CT|CST|CDT|GMT|UTC|HD|BK|SD|FHD|4K|UHD|HQ|EVENT\s+ONLY|LIVE\s+NOW|LIVE|REPLAY|HITS|RAW|MULTI-AUDIO|MULTISUB|MULTILANG|MULTIAUDIO|MULTI)\s*[\)\]]").unwrap()
 });
+static STREAM_MNF_PREFIX_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)^(MNF|TNF|SNF|SLING|S)(?:\s*[:|-]\s*|\s+)").unwrap());
+static STREAM_LEAGUE_PREFIX_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)^(NBA|NFL|NHL|MLB|UFC|MLS)(?:\s*[:|-]\s*|\s+\d)").unwrap());
+static STREAM_GENERIC_PREFIX_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)^([A-Z0-9/]{1,7})(?:\s*[|:-]\s*|\s+)").unwrap());
+static STREAM_LEAGUE_PIPE_PREFIX_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)^(NBA|NFL|NHL|MLB|UFC|MLS)(?:\s*[|:-]\s*|\s+\d)").unwrap());
 
 /// VOD-specific foreign keywords for is_english_vod check.
 /// Uses HashSet for O(1) lookup instead of regex.
@@ -681,8 +688,8 @@ pub fn clean_american_name(name: &str) -> String {
 
     // Extra cleanup for leading/trailing colons and dots
     let cleaned_str = cleaned
-        .trim_start_matches(|c: char| c == ':' || c == '.' || c == '|' || c == '-' || c == ' ')
-        .trim_end_matches(|c: char| c == ':' || c == '.' || c == '|' || c == '-' || c == ' ')
+        .trim_start_matches([':', '.', '|', '-', ' '])
+        .trim_end_matches([':', '.', '|', '-', ' '])
         .trim();
 
     if cleaned_str.is_empty() {
@@ -867,12 +874,10 @@ pub fn parse_category(name: &str) -> ParsedCategory {
                 "NBA", "NFL", "MLB", "NHL", "UFC", "MLS", "NCAAF", "NCAAB", "PPV",
             ]
             .contains(&code);
-            let has_separator = display_name
-                .find(|c| c == '|' || c == ':' || c == '-')
-                .is_some();
+            let has_separator = display_name.find(['|', ':', '-']).is_some();
 
             if !is_league || has_separator {
-                if let Some(pos) = display_name.find(|c| c == '|' || c == ':' || c == '-') {
+                if let Some(pos) = display_name.find(['|', ':', '-']) {
                     display_name = display_name[pos + 1..].trim().to_string();
                 } else if let Some(pos) = display_name.find(' ') {
                     display_name = display_name[pos + 1..].trim().to_string();
@@ -1076,16 +1081,17 @@ pub fn parse_stream(name: &str, provider_tz: Option<&str>) -> ParsedStream {
 
         // Remove "MNF", "TNF", "SNF" game day labels AND league prefixes ONLY when followed by separator or number
         // We want to keep "NBA TV" intact but strip "NBA | Game" or "NBA 01: Something"
-        let re_mnf = Regex::new(r"(?i)^(MNF|TNF|SNF|SLING|S)(?:\s*[:|-]\s*|\s+)").unwrap();
-        if re_mnf.is_match(&display_name) {
-            display_name = re_mnf.replace(&display_name, "").to_string();
+        if STREAM_MNF_PREFIX_REGEX.is_match(&display_name) {
+            display_name = STREAM_MNF_PREFIX_REGEX
+                .replace(&display_name, "")
+                .to_string();
             clean_loop = true;
         }
         // Strip league prefix ONLY if followed by separator (:|) or number, NOT regular words like "TV"
-        let re_league_prefix =
-            Regex::new(r"(?i)^(NBA|NFL|NHL|MLB|UFC|MLS)(?:\s*[:|-]\s*|\s+\d)").unwrap();
-        if re_league_prefix.is_match(&display_name) {
-            display_name = re_league_prefix.replace(&display_name, "").to_string();
+        if STREAM_LEAGUE_PREFIX_REGEX.is_match(&display_name) {
+            display_name = STREAM_LEAGUE_PREFIX_REGEX
+                .replace(&display_name, "")
+                .to_string();
             clean_loop = true;
         }
 
@@ -1107,22 +1113,7 @@ pub fn parse_stream(name: &str, provider_tz: Option<&str>) -> ParsedStream {
         let suffix = display_name[idx + 1..].trim();
         // If the suffix is significant (more than just quality), and the prefix looks like a category/channel label, take suffix
         if suffix.len() > 5 && !suffix.chars().all(|c| c.is_numeric() || c == ' ') {
-            // Heuristic: If suffix starts with a digit and "x" or "vs", it's likely the event part "01 x Team"
-            // And the prefix is just channel spam.
-            let re_event_start = Regex::new(r"(?i)^\d+\s*(x|vs|at|-)\s+").unwrap();
-            if re_event_start.is_match(suffix) {
-                display_name = suffix.to_string();
-            }
-            // Heuristic 2: If the part after contains " x " or " vs "
-            else if (suffix.to_uppercase().contains(" VS ")
-                || suffix.to_uppercase().contains(" X ")
-                || suffix.to_uppercase().contains(" AT "))
-                && suffix.len() > 5
-            {
-                display_name = suffix.to_string();
-            } else {
-                display_name = suffix.to_string();
-            }
+            display_name = suffix.to_string();
         }
     }
 
@@ -1141,8 +1132,7 @@ pub fn parse_stream(name: &str, provider_tz: Option<&str>) -> ParsedStream {
     let mut clean_loop = true;
     while clean_loop {
         clean_loop = false;
-        let re_prefix = Regex::new(r"(?i)^([A-Z0-9/]{1,7})(?:\s*[|:-]\s*|\s+)").unwrap();
-        if let Some(caps) = re_prefix.captures(&display_name) {
+        if let Some(caps) = STREAM_GENERIC_PREFIX_REGEX.captures(&display_name) {
             let code = caps.get(1).unwrap().as_str().to_uppercase();
             // Country codes that should always be stripped
             let country_codes = [
@@ -1158,21 +1148,23 @@ pub fn parse_stream(name: &str, provider_tz: Option<&str>) -> ParsedStream {
                 .to_uppercase();
 
             if country_codes.iter().any(|&c| check_name.starts_with(c)) {
-                display_name = re_prefix.replace(&display_name, "").to_string();
+                display_name = STREAM_GENERIC_PREFIX_REGEX
+                    .replace(&display_name, "")
+                    .to_string();
                 // Extra trim to remove following dashes if any
                 display_name = display_name
-                    .trim_start_matches(|c: char| c == '-' || c == '|' || c == ':' || c == ' ')
+                    .trim_start_matches(['-', '|', ':', ' '])
                     .to_string();
                 clean_loop = true;
             } else if league_codes.contains(&code.as_str()) {
                 // For leagues, only strip if followed by separator (: | -) or number, NOT regular words
-                let re_league =
-                    Regex::new(r"(?i)^(NBA|NFL|NHL|MLB|UFC|MLS)(?:\s*[|:-]\s*|\s+\d)").unwrap();
-                if re_league.is_match(&display_name) {
+                if STREAM_LEAGUE_PIPE_PREFIX_REGEX.is_match(&display_name) {
                     if country.is_none() {
                         country = Some(code);
                     }
-                    display_name = re_league.replace(&display_name, "").to_string();
+                    display_name = STREAM_LEAGUE_PIPE_PREFIX_REGEX
+                        .replace(&display_name, "")
+                        .to_string();
                     clean_loop = true;
                 }
             }
@@ -1305,17 +1297,7 @@ pub fn parse_stream(name: &str, provider_tz: Option<&str>) -> ParsedStream {
                             _ => chrono_tz::Europe::London,
                         }
                     } else {
-                        // Heuristic: If it looks like a US League but no country prefix, default to Central
-                        if upper.contains("NFL")
-                            || upper.contains("NBA")
-                            || upper.contains("MLB")
-                            || upper.contains("NHL")
-                            || upper.contains("UFC")
-                        {
-                            chrono_tz::America::Chicago
-                        } else {
-                            chrono_tz::America::Chicago
-                        }
+                        chrono_tz::America::Chicago
                     }
                 }
             };
@@ -1441,13 +1423,8 @@ pub fn parse_stream(name: &str, provider_tz: Option<&str>) -> ParsedStream {
 
         // If we have a sports event, we can try to get a better start_time if not already set
         if start_time.is_none() && !event.start_time_raw.is_empty() {
-            let parsed_dt = if let Ok(dt) =
-                NaiveDateTime::parse_from_str(&event.start_time_raw, "%Y-%m-%d %H:%M:%S")
-            {
-                Some(dt)
-            } else {
-                None
-            };
+            let parsed_dt =
+                NaiveDateTime::parse_from_str(&event.start_time_raw, "%Y-%m-%d %H:%M:%S").ok();
             if let Some(naive_dt) = parsed_dt {
                 let source_tz = provider_tz
                     .and_then(|ptz| ptz.parse::<chrono_tz::Tz>().ok())
@@ -1815,9 +1792,9 @@ pub fn parse_movie(name: &str) -> ParsedMovie {
     ];
 
     for (pattern, lang) in lang_patterns {
-        if name.starts_with(pattern) {
+        if let Some(stripped) = name.strip_prefix(pattern) {
             language = Some(lang.to_string());
-            title = name[pattern.len()..].trim().to_string();
+            title = stripped.trim().to_string();
             break;
         }
     }
@@ -1828,7 +1805,7 @@ pub fn parse_movie(name: &str) -> ParsedMovie {
     if let Some(caps) = YEAR_REGEX.captures(&title) {
         if let Some(m) = caps.get(1) {
             if let Ok(y) = m.as_str().parse::<u16>() {
-                if y >= 1900 && y <= 2030 {
+                if (1900..=2030).contains(&y) {
                     found_year = Some(y);
                 }
             }

--- a/src/player.rs
+++ b/src/player.rs
@@ -55,6 +55,7 @@ impl Player {
         }
     }
 
+    #[allow(dead_code)]
     async fn check_stream_health(&self, url: &str) -> Result<(), anyhow::Error> {
         // Build a client that mimics the player's behavior (Chrome UA)
         let client = reqwest::Client::builder()

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,17 +1,13 @@
+use crate::config::PlayerEngine;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
-use crate::config::PlayerEngine;
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::process::{Child, Command, Stdio};
 
 #[cfg(not(target_arch = "wasm32"))]
-
-
 #[cfg(not(target_arch = "wasm32"))]
-
-
 #[cfg(target_arch = "wasm32")]
 use web_sys::window;
 
@@ -21,6 +17,12 @@ pub struct Player {
     process: Arc<Mutex<Option<Child>>>,
     #[cfg(not(target_arch = "wasm32"))]
     ipc_path: Arc<Mutex<Option<PathBuf>>>,
+}
+
+impl Default for Player {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Player {
@@ -40,13 +42,19 @@ impl Player {
 
     /// Start the selected player engine and return the IPC pipe path for monitoring
     #[cfg(not(target_arch = "wasm32"))]
-    pub async fn play(&self, url: &str, engine: PlayerEngine, use_default_mpv: bool, smooth_motion: bool) -> Result<(), anyhow::Error> {
+    pub async fn play(
+        &self,
+        url: &str,
+        engine: PlayerEngine,
+        use_default_mpv: bool,
+        smooth_motion: bool,
+    ) -> Result<(), anyhow::Error> {
         // We SKIP the pre-flight `check_stream_health(url)` here because doing a GET request
         // immediately before launching the player can trigger the IPTV provider's
         // "Max 1 Connection" rule (the health check leaves a ghost connection open
         // for 30-60 seconds on their backend). This would cause the provider
         // to gracefully kill the stream ~45 seconds in!
-        
+
         self.stop();
 
         match engine {
@@ -68,12 +76,15 @@ impl Player {
         // We use a stream request but abort immediately to check connectivity/headers.
         // HEAD often fails on some IPTV servers, so a started GET is safer logic-wise.
         let mut result = client.get(url).send().await;
-        
+
         // Resilience: Fallback to DoH if DNS fails for the stream health check
         if let Err(ref e) = result {
             if crate::doh::is_dns_error(e) {
                 #[cfg(debug_assertions)]
-                println!("DEBUG: Health check DNS error detected for {}. Trying DoH fallback...", url);
+                println!(
+                    "DEBUG: Health check DNS error detected for {}. Trying DoH fallback...",
+                    url
+                );
 
                 if let Some(resp) = crate::doh::try_doh_fallback(&client, url).await {
                     result = Ok(resp);
@@ -86,25 +97,35 @@ impl Player {
                 if resp.status().is_success() || resp.status().is_redirection() {
                     Ok(())
                 } else {
-                    Err(anyhow::anyhow!("Stream returned error status: {} (Server might be offline/blocking)", resp.status()))
+                    Err(anyhow::anyhow!(
+                        "Stream returned error status: {} (Server might be offline/blocking)",
+                        resp.status()
+                    ))
                 }
-            },
+            }
             Err(e) => {
                 // Provide a user-friendly error description using shared DNS detection
                 if crate::doh::is_dns_error(&e) {
-                     Err(anyhow::anyhow!("Stream Server Unreachable. The host likely does not exist or is blocked (DNS Error). Details: {}", e))
+                    Err(anyhow::anyhow!("Stream Server Unreachable. The host likely does not exist or is blocked (DNS Error). Details: {}", e))
                 } else if e.is_connect() || e.is_timeout() {
-                     Err(anyhow::anyhow!("Stream Connection Failed. Server may be slow or offline. Details: {}", e))
+                    Err(anyhow::anyhow!(
+                        "Stream Connection Failed. Server may be slow or offline. Details: {}",
+                        e
+                    ))
                 } else {
-                     Err(anyhow::anyhow!("Stream Check Failed: {}", e))
+                    Err(anyhow::anyhow!("Stream Check Failed: {}", e))
                 }
             }
         }
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn play_mpv(&self, url: &str, use_default_mpv: bool, smooth_motion: bool) -> Result<(), anyhow::Error> {
-
+    fn play_mpv(
+        &self,
+        url: &str,
+        use_default_mpv: bool,
+        smooth_motion: bool,
+    ) -> Result<(), anyhow::Error> {
         // Find mpv executable, checking PATH and common installation locations
         let mpv_path = crate::setup::get_mpv_path().ok_or_else(|| {
             let hint = if cfg!(target_os = "macos") {
@@ -131,7 +152,7 @@ impl Player {
         };
 
         let mut cmd = Command::new(&mpv_path);
-        
+
         // Add Referrer validation (Common anti-scraping measure)
         if let Some(scheme_end) = url.find("://") {
             let rest = &url[scheme_end + 3..];
@@ -141,7 +162,7 @@ impl Player {
                 cmd.arg(format!("--referrer={}", base));
             }
         }
-        
+
         let _is_live = url.contains("/live/") || url.contains(".m3u8");
 
         cmd.arg(url)
@@ -154,9 +175,9 @@ impl Player {
         // Apply smooth motion interpolation if enabled
         if smooth_motion {
             cmd.arg("--video-sync=display-resample") // Smooth motion sync (required for interpolation)
-               .arg("--interpolation=yes") // Frame generation / motion smoothing
-               .arg("--tscale=linear")     // Soap opera effect - smooth motion blending (GPU friendly)
-               .arg("--tscale-clamp=0.0"); // Allow full blending for maximum smoothness
+                .arg("--interpolation=yes") // Frame generation / motion smoothing
+                .arg("--tscale=linear") // Soap opera effect - smooth motion blending (GPU friendly)
+                .arg("--tscale-clamp=0.0"); // Allow full blending for maximum smoothness
         }
 
         // Only apply optimizations if not using default MPV settings
@@ -182,10 +203,10 @@ impl Player {
                .arg("--tls-verify=no");
 
             if cfg!(target_os = "windows") {
-                cmd.arg("--d3d11-flip=yes")            // Modern Windows presentation (faster)
-                   .arg("--gpu-api=d3d11");             // Force D3D11 (faster than OpenGL on Windows)
+                cmd.arg("--d3d11-flip=yes") // Modern Windows presentation (faster)
+                    .arg("--gpu-api=d3d11"); // Force D3D11 (faster than OpenGL on Windows)
             } else if cfg!(target_os = "macos") {
-                cmd.arg("--gpu-api=opengl");            // Generally safe default for macOS mpv
+                cmd.arg("--gpu-api=opengl"); // Generally safe default for macOS mpv
             }
         }
 
@@ -205,23 +226,25 @@ impl Player {
 
         // Disconnect from terminal input/output to prevent hotkey conflicts
         cmd.stdin(Stdio::null())
-           .stdout(Stdio::null())
-           .stderr(Stdio::null());
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
 
         let child = cmd.spawn();
 
         match child {
             Ok(child) => {
                 {
-                    let mut guard = self.process.lock().map_err(|e| {
-                        anyhow::anyhow!("Failed to lock process mutex: {}", e)
-                    })?;
+                    let mut guard = self
+                        .process
+                        .lock()
+                        .map_err(|e| anyhow::anyhow!("Failed to lock process mutex: {}", e))?;
                     *guard = Some(child);
                 }
                 {
-                    let mut ipc_guard = self.ipc_path.lock().map_err(|e| {
-                        anyhow::anyhow!("Failed to lock IPC path mutex: {}", e)
-                    })?;
+                    let mut ipc_guard = self
+                        .ipc_path
+                        .lock()
+                        .map_err(|e| anyhow::anyhow!("Failed to lock IPC path mutex: {}", e))?;
                     *ipc_guard = Some(PathBuf::from(&pipe_name));
                 }
                 Ok(())
@@ -237,10 +260,7 @@ impl Player {
                 } else {
                     String::new()
                 };
-                Err(anyhow::anyhow!(
-                    "Failed to start mpv: {}.{}",
-                    e, hint
-                ))
+                Err(anyhow::anyhow!("Failed to start mpv: {}.{}", e, hint))
             }
         }
     }
@@ -248,12 +268,11 @@ impl Player {
     #[cfg(not(target_arch = "wasm32"))]
     fn play_vlc(&self, url: &str, smooth_motion: bool) -> Result<(), anyhow::Error> {
         // Find vlc executable
-        let vlc_path = crate::setup::get_vlc_path().ok_or_else(|| {
-            anyhow::anyhow!("VLC not found. Please install VLC.")
-        })?;
+        let vlc_path = crate::setup::get_vlc_path()
+            .ok_or_else(|| anyhow::anyhow!("VLC not found. Please install VLC."))?;
 
         let mut cmd = Command::new(&vlc_path);
-        
+
         // Add Referrer validation (Common anti-scraping measure)
         // Manual parsing to avoid adding 'url' crate dependency
         if let Some(scheme_end) = url.find("://") {
@@ -277,12 +296,12 @@ impl Player {
         // Apply smooth motion (deinterlacing) if enabled
         if smooth_motion {
             cmd.arg("--video-filter=deinterlace")
-               .arg("--deinterlace-mode=bob");
+                .arg("--deinterlace-mode=bob");
         }
         // DISCONNECT from terminal
         cmd.stdin(Stdio::null())
-           .stdout(Stdio::null())
-           .stderr(Stdio::null());
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
 
         #[cfg(windows)]
         {
@@ -292,27 +311,31 @@ impl Player {
         }
 
         let child = cmd.spawn()?;
-        
+
         {
-            let mut guard = self.process.lock().map_err(|e| {
-                anyhow::anyhow!("Failed to lock process mutex: {}", e)
-            })?;
+            let mut guard = self
+                .process
+                .lock()
+                .map_err(|e| anyhow::anyhow!("Failed to lock process mutex: {}", e))?;
             *guard = Some(child);
         }
-        
+
         Ok(())
     }
 
     /// Read the last few lines of the player logs to find errors
     pub fn get_last_error_from_log(&self) -> Option<String> {
         let logs = ["mpv_playback.log", "vlc_playback.log"];
-        
+
         for log_file in logs {
             if let Ok(content) = std::fs::read_to_string(log_file) {
                 let lines: Vec<&str> = content.lines().rev().take(15).collect();
                 for line in lines {
                     let lower = line.to_lowercase();
-                    if lower.contains("error") || lower.contains("failed") || lower.contains("fatal") {
+                    if lower.contains("error")
+                        || lower.contains("failed")
+                        || lower.contains("fatal")
+                    {
                         // Clean up common VLC/MPV prefixes for cleaner UI display
                         let cleaned = line.split("]: ").last().unwrap_or(line);
                         return Some(cleaned.to_string());
@@ -375,7 +398,13 @@ impl Player {
     }
 
     #[cfg(target_arch = "wasm32")]
-    pub fn play(&self, url: &str, _engine: PlayerEngine, _use_default_mpv: bool, _smooth_motion: bool) -> Result<(), anyhow::Error> {
+    pub fn play(
+        &self,
+        url: &str,
+        _engine: PlayerEngine,
+        _use_default_mpv: bool,
+        _smooth_motion: bool,
+    ) -> Result<(), anyhow::Error> {
         self.stop();
         if let Some(win) = window() {
             let _ = win.alert_with_message(&format!("Play stream: {}", url));

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -10,13 +10,22 @@ pub fn preprocess_categories(
     _account_name: &str,
 ) {
     if !cats.iter().any(|c| c.category_id == "ALL") {
-        cats.insert(0, Category {
-            category_id: "ALL".to_string(),
-            category_name: if is_live { "All Channels".to_string() } else if is_vod { "All Movies".to_string() } else { "All Series".to_string() },
-            is_american: true,
-            is_english: true,
-            ..Default::default()
-        });
+        cats.insert(
+            0,
+            Category {
+                category_id: "ALL".to_string(),
+                category_name: if is_live {
+                    "All Channels".to_string()
+                } else if is_vod {
+                    "All Movies".to_string()
+                } else {
+                    "All Series".to_string()
+                },
+                is_american: true,
+                is_english: true,
+                ..Default::default()
+            },
+        );
     }
 
     let use_merica = modes.contains(&crate::config::ProcessingMode::Merica);
@@ -26,7 +35,9 @@ pub fn preprocess_categories(
     // 1. Filter
     cats.retain_mut(|c| {
         // Keep ALL category always
-        if c.category_id == "ALL" { return true; }
+        if c.category_id == "ALL" {
+            return true;
+        }
 
         let mut keep = true;
 
@@ -41,31 +52,31 @@ pub fn preprocess_categories(
             }
 
             // All English Logic (if Merica not active, or additive?)
-            // If AllEnglish is ON, we only keep English. 
+            // If AllEnglish is ON, we only keep English.
             // If Merica is ALSO on, Merica is stricter, so it implicitly satisfies AllEnglish mostly.
             // But let's treat them as additive filters (AND).
             if use_all_english {
                 c.is_english = crate::parser::is_english_live(&c.category_name);
-                if !c.is_english { keep = false; }
+                if !c.is_english {
+                    keep = false;
+                }
             }
 
             // Sports Mode Logic - If ONLY Sports is on, we filter for sports.
             // If Sports AND Merica are on, we filter for American Sports.
-            if use_sports {
-                if !crate::parser::is_sports_content(&c.category_name) {
-                    keep = false;
-                }
+            if use_sports && !crate::parser::is_sports_content(&c.category_name) {
+                keep = false;
             }
         } else {
             // VOD/Series
             if use_merica || use_all_english {
                 c.is_english = crate::parser::is_english_vod(&c.category_name);
-                if !c.is_english { keep = false; }
-            }
-            if use_sports {
-                if !crate::parser::is_sports_content(&c.category_name) {
+                if !c.is_english {
                     keep = false;
                 }
+            }
+            if use_sports && !crate::parser::is_sports_content(&c.category_name) {
+                keep = false;
             }
         }
 
@@ -82,7 +93,7 @@ pub fn preprocess_categories(
             c.clean_name = c.category_name.clone();
         }
         c.search_name = c.clean_name.to_lowercase();
-        
+
         // Cache parsed metadata to enable O(1) TUI rendering
         if c.cached_parsed.is_none() {
             c.cached_parsed = Some(Box::new(crate::parser::parse_category(&c.category_name)));
@@ -91,17 +102,25 @@ pub fn preprocess_categories(
 
     // 3. Sort - Parallelized
     cats.par_sort_by(|a, b| {
-        if a.category_id == "ALL" { return std::cmp::Ordering::Less; }
-        if b.category_id == "ALL" { return std::cmp::Ordering::Greater; }
+        if a.category_id == "ALL" {
+            return std::cmp::Ordering::Less;
+        }
+        if b.category_id == "ALL" {
+            return std::cmp::Ordering::Greater;
+        }
         let a_fav = favorites.contains(&a.category_id);
         let b_fav = favorites.contains(&b.category_id);
-        
+
         // Sports Mode Hoisting
         if use_sports {
             let a_sport = crate::parser::is_sports_content(&a.category_name);
             let b_sport = crate::parser::is_sports_content(&b.category_name);
-            if a_sport && !b_sport { return std::cmp::Ordering::Less; }
-            if !a_sport && b_sport { return std::cmp::Ordering::Greater; }
+            if a_sport && !b_sport {
+                return std::cmp::Ordering::Less;
+            }
+            if !a_sport && b_sport {
+                return std::cmp::Ordering::Greater;
+            }
         }
 
         match (a_fav, b_fav) {
@@ -128,26 +147,38 @@ pub fn preprocess_streams(
 
     if let Some(ref tx) = tx {
         let _ = tx.try_send(crate::app::AsyncAction::LoadingMessage(
-            "Phase 1/3: Stripping provider separators...".to_string()
+            "Phase 1/3: Stripping provider separators...".to_string(),
         ));
     }
-    
+
     // 0. Strip out provider-injected separator/header entries.
     streams.retain(|s| {
         let name = s.name.trim();
-        if name.is_empty() { return false; }
-        
-        let sep_chars: &[char] = &['❖', '#', '═', '●', '◆', '■', '▬', '━', '─', '☆', '★', '◇', '◈', '▶', '▷'];
+        if name.is_empty() {
+            return false;
+        }
+
+        let sep_chars: &[char] = &[
+            '❖', '#', '═', '●', '◆', '■', '▬', '━', '─', '☆', '★', '◇', '◈', '▶', '▷',
+        ];
         let sep_count = name.chars().filter(|c| sep_chars.contains(c)).count();
-        if sep_count >= 2 { return false; }
-        if name.chars().all(|c| sep_chars.contains(&c) || c.is_whitespace()) { return false; }
+        if sep_count >= 2 {
+            return false;
+        }
+        if name
+            .chars()
+            .all(|c| sep_chars.contains(&c) || c.is_whitespace())
+        {
+            return false;
+        }
         true
     });
 
     if let Some(ref tx) = tx {
-        let _ = tx.try_send(crate::app::AsyncAction::LoadingMessage(
-            format!("Phase 2/3: Cleaning metadata for {} streams...", streams.len())
-        ));
+        let _ = tx.try_send(crate::app::AsyncAction::LoadingMessage(format!(
+            "Phase 2/3: Cleaning metadata for {} streams...",
+            streams.len()
+        )));
     }
 
     // 1. Filter
@@ -157,22 +188,28 @@ pub fn preprocess_streams(
         if is_live {
             if use_merica {
                 s.is_american = crate::parser::is_american_live(&s.name);
-                if !s.is_american { keep = false; }
+                if !s.is_american {
+                    keep = false;
+                }
             }
             if use_all_english {
                 s.is_english = crate::parser::is_english_live(&s.name);
-                if !s.is_english { keep = false; }
+                if !s.is_english {
+                    keep = false;
+                }
             }
-            if use_sports {
-                 if !crate::parser::is_sports_content(&s.name) { keep = false; }
+            if use_sports && !crate::parser::is_sports_content(&s.name) {
+                keep = false;
             }
         } else {
             if use_merica || use_all_english {
                 s.is_english = crate::parser::is_english_vod(&s.name);
-                if !s.is_english { keep = false; }
+                if !s.is_english {
+                    keep = false;
+                }
             }
-            if use_sports {
-                 if !crate::parser::is_sports_content(&s.name) { keep = false; }
+            if use_sports && !crate::parser::is_sports_content(&s.name) {
+                keep = false;
             }
         }
         keep
@@ -181,29 +218,35 @@ pub fn preprocess_streams(
     // 2. Process (Clean names & Metadata) - Parallelized via Rayon
     use rayon::prelude::*;
     let should_clean = use_merica;
-    
+
     if let Some(ref tx) = tx {
-        let _ = tx.try_send(crate::app::AsyncAction::LoadingMessage(
-            format!("Phase 2/3: Cleaning metadata for {} streams (Multi-Core)...", streams.len())
-        ));
+        let _ = tx.try_send(crate::app::AsyncAction::LoadingMessage(format!(
+            "Phase 2/3: Cleaning metadata for {} streams (Multi-Core)...",
+            streams.len()
+        )));
     }
 
     streams.par_iter_mut().for_each(|s| {
         if should_clean {
             s.clean_name = crate::parser::clean_american_name(&s.name);
-            s.name = s.clean_name.clone(); 
+            s.name = s.clean_name.clone();
         } else {
             s.clean_name = s.name.clone();
         }
-        
+
         // Sports Mode Icon Prefixing
         if use_sports && is_live {
             if let Some(league) = s.epg_channel_id.as_ref().or(Some(&s.name)) {
                 let lower = league.to_lowercase();
-                if lower.contains("nba") { s.clean_name = format!("🏀 {}", s.clean_name); }
-                else if lower.contains("nfl") { s.clean_name = format!("🏈 {}", s.clean_name); }
-                else if lower.contains("mlb") { s.clean_name = format!("⚾ {}", s.clean_name); }
-                else if lower.contains("nhl") { s.clean_name = format!("🏒 {}", s.clean_name); }
+                if lower.contains("nba") {
+                    s.clean_name = format!("🏀 {}", s.clean_name);
+                } else if lower.contains("nfl") {
+                    s.clean_name = format!("🏈 {}", s.clean_name);
+                } else if lower.contains("mlb") {
+                    s.clean_name = format!("⚾ {}", s.clean_name);
+                } else if lower.contains("nhl") {
+                    s.clean_name = format!("🏒 {}", s.clean_name);
+                }
             }
         }
 
@@ -216,14 +259,14 @@ pub fn preprocess_streams(
             s.cached_parsed = Some(Box::new(crate::parser::parse_stream(&s.name, None)));
         }
     });
-    
+
     // 3. Sort - Zero-Copy Architectural Pattern
     streams.sort_by(|a, b| {
         let a_id = get_id_str(&a.stream_id);
         let b_id = get_id_str(&b.stream_id);
         let a_fav = favorites.contains(&a_id);
         let b_fav = favorites.contains(&b_id);
-        
+
         // Tier 1: Favorites Hoisting
         match (a_fav, b_fav) {
             (true, false) => return std::cmp::Ordering::Less,

--- a/src/preprocessing.rs
+++ b/src/preprocessing.rs
@@ -7,7 +7,7 @@ pub fn preprocess_categories(
     modes: &[crate::config::ProcessingMode],
     is_live: bool,
     is_vod: bool,
-    account_name: &str,
+    _account_name: &str,
 ) {
     if !cats.iter().any(|c| c.category_id == "ALL") {
         cats.insert(0, Category {
@@ -19,7 +19,6 @@ pub fn preprocess_categories(
         });
     }
 
-    let account_lower = account_name.to_lowercase();
     let use_merica = modes.contains(&crate::config::ProcessingMode::Merica);
     let use_sports = modes.contains(&crate::config::ProcessingMode::Sports);
     let use_all_english = modes.contains(&crate::config::ProcessingMode::AllEnglish);
@@ -35,26 +34,10 @@ pub fn preprocess_categories(
             // Merica Mode Logic
             if use_merica {
                 c.is_american = crate::parser::is_american_live(&c.category_name);
-                
-                // Strong Playlist overrides
-                if account_lower.contains("strong") {
-                     let name = c.category_name.to_uppercase();
-                     if name.starts_with("AR |") || name.starts_with("AR|") || name.starts_with("AR :") {
-                         c.is_american = false;
-                     }
-                     if name.contains("NBA PASS") || name.contains("NBA REAL") || name.contains("NHL REAL") {
-                         c.is_american = false;
-                     }
+
+                if !c.is_american {
+                    keep = false;
                 }
-                // Trex Playlist overrides
-                if account_lower.contains("trex") {
-                     let name = c.category_name.to_uppercase();
-                     if name.contains("NBA NETWORK") || name.contains("NBA LEAGUE PASS") {
-                         c.is_american = false;
-                     }
-                }
-                
-                if !c.is_american { keep = false; }
             }
 
             // All English Logic (if Merica not active, or additive?)
@@ -259,4 +242,59 @@ pub fn preprocess_streams(
         // Tier 3: Lexicographical fallback (O(1) reference comparison)
         a.name.cmp(&b.name)
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::Category;
+    use crate::config::ProcessingMode;
+
+    fn category(id: &str, name: &str) -> Category {
+        Category {
+            category_id: id.to_string(),
+            category_name: name.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_merica_category_filter_keeps_us_packages_ppv_and_247() {
+        let mut categories = vec![
+            category("1", "NBA Package"),
+            category("2", "NBA League Pass"),
+            category("3", "NHL Real"),
+            category("4", "PPV Events"),
+            category("5", "24/7 Channels"),
+            category("6", "UK PPV"),
+            category("7", "CA 24/7"),
+            category("8", "IN | 24/7 Cricket"),
+            category("9", "International PPV"),
+        ];
+
+        preprocess_categories(
+            &mut categories,
+            &HashSet::new(),
+            &[ProcessingMode::Merica],
+            true,
+            false,
+            "Trex",
+        );
+
+        let names: Vec<_> = categories
+            .iter()
+            .map(|c| c.category_name.as_str())
+            .collect();
+
+        assert!(names.contains(&"All Channels"));
+        assert!(names.contains(&"NBA Package"));
+        assert!(names.contains(&"NBA League Pass"));
+        assert!(names.contains(&"NHL Real"));
+        assert!(names.contains(&"PPV Events"));
+        assert!(names.contains(&"24/7 Channels"));
+        assert!(!names.contains(&"UK PPV"));
+        assert!(!names.contains(&"CA 24/7"));
+        assert!(!names.contains(&"IN | 24/7 Cricket"));
+        assert!(!names.contains(&"International PPV"));
+    }
 }

--- a/src/scores.rs
+++ b/src/scores.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
 use anyhow::Result;
 use reqwest::Client;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EspnResponse {
@@ -10,7 +10,7 @@ pub struct EspnResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EspnEvent {
     pub id: String,
-    pub date: String, // ISO 8601 UTC
+    pub date: String,               // ISO 8601 UTC
     pub short_name: Option<String>, // e.g. "CHI @ GB"
     pub status: EspnStatus,
     pub competitions: Vec<EspnCompetition>,
@@ -29,8 +29,8 @@ pub struct EspnStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EspnStatusType {
     pub id: String,
-    pub name: String, // STATUS_SCHEDULED, STATUS_IN_PROGRESS, STATUS_FINAL
-    pub state: String, // "pre", "in", "post"
+    pub name: String,           // STATUS_SCHEDULED, STATUS_IN_PROGRESS, STATUS_FINAL
+    pub state: String,          // "pre", "in", "post"
     pub detail: Option<String>, // "Final", "OT", "10:00 - 1st Quarter"
     pub short_detail: Option<String>, // "Final", "1st", "Halftime"
 }
@@ -79,7 +79,7 @@ pub struct EspnProbability {
 pub struct EspnHeadline {
     #[serde(rename = "type")]
     pub headline_type: Option<String>, // "Recap"
-    pub description: Option<String>,   // Full headline text
+    pub description: Option<String>,     // Full headline text
     pub short_link_text: Option<String>, // Short summary
 }
 
@@ -94,7 +94,7 @@ pub struct EspnSeries {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EspnLeaderCategory {
-    pub name: Option<String>,     // "points", "rebounds", "assists"
+    pub name: Option<String>, // "points", "rebounds", "assists"
     pub leaders: Option<Vec<EspnLeaderEntry>>,
 }
 
@@ -141,13 +141,13 @@ pub struct EspnCompetitor {
 pub struct EspnTeam {
     pub id: String,
     pub uid: Option<String>,
-    pub location: Option<String>, // "Chicago"
-    pub name: Option<String>,     // "Bears"
+    pub location: Option<String>,     // "Chicago"
+    pub name: Option<String>,         // "Bears"
     pub abbreviation: Option<String>, // "CHI"
     pub display_name: Option<String>, // "Chicago Bears"
     pub color: Option<String>,
     pub alternate_color: Option<String>,
-    pub logo: Option<String>,     // Team logo URL
+    pub logo: Option<String>, // Team logo URL
 }
 
 #[derive(Debug, Clone)]
@@ -155,14 +155,14 @@ pub struct ScoreGame {
     pub id: String,
     pub league: String,
     pub start_time: String,
-    pub status_state: String, // pre, in, post
+    pub status_state: String,  // pre, in, post
     pub status_detail: String, // "Final", "12:43 1st"
     pub home_team: String,
     pub home_score: String,
     pub home_abbr: String,
-    pub home_color: Option<String>,    // Team primary color hex
-    pub home_record: Option<String>,   // e.g., "24-18"
-    pub home_logo: Option<String>,     // Team logo URL
+    pub home_color: Option<String>,  // Team primary color hex
+    pub home_record: Option<String>, // e.g., "24-18"
+    pub home_logo: Option<String>,   // Team logo URL
     pub away_team: String,
     pub away_score: String,
     pub away_abbr: String,
@@ -175,17 +175,23 @@ pub struct ScoreGame {
     pub venue_city: Option<String>,
     pub venue_state: Option<String>,
     // Enhanced intelligence data
-    pub broadcasts: Vec<String>,          // TV networks
-    pub last_play: Option<String>,        // "Lakers Full timeout"
-    pub home_win_pct: Option<f64>,        // Win probability
+    pub broadcasts: Vec<String>,   // TV networks
+    pub last_play: Option<String>, // "Lakers Full timeout"
+    pub home_win_pct: Option<f64>, // Win probability
     pub away_win_pct: Option<f64>,
-    pub headline: Option<String>,         // Game summary/recap headline
-    pub series_summary: Option<String>,   // Playoff series status "Series tied 2-2"
-    pub top_scorer: Option<String>,       // "Ja Morant - 24 PTS"
+    pub headline: Option<String>,       // Game summary/recap headline
+    pub series_summary: Option<String>, // Playoff series status "Series tied 2-2"
+    pub top_scorer: Option<String>,     // "Ja Morant - 24 PTS"
 }
 
 pub struct ScoreService {
     client: Client,
+}
+
+impl Default for ScoreService {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ScoreService {
@@ -207,7 +213,7 @@ impl ScoreService {
             ("hockey/nhl", "NHL"),
             ("baseball/mlb", "MLB"),
             ("soccer/usa.1", "MLS"),
-            ("soccer/eng.1", "EPL"), 
+            ("soccer/eng.1", "EPL"),
         ];
 
         let mut all_games = Vec::new();
@@ -229,51 +235,72 @@ impl ScoreService {
                                 if let (Some(h), Some(a)) = (home, away) {
                                     let h_name = h.team.display_name.clone().unwrap_or_default();
                                     let a_name = a.team.display_name.clone().unwrap_or_default();
-                                    
-                                    let venue_name = comp.venue.as_ref().and_then(|v| v.full_name.clone());
-                                    let (venue_city, venue_state) = if let Some(addr) = comp.venue.as_ref().and_then(|v| v.address.as_ref()) {
+
+                                    let venue_name =
+                                        comp.venue.as_ref().and_then(|v| v.full_name.clone());
+                                    let (venue_city, venue_state) = if let Some(addr) =
+                                        comp.venue.as_ref().and_then(|v| v.address.as_ref())
+                                    {
                                         (addr.city.clone(), addr.state.clone())
                                     } else {
                                         (None, None)
                                     };
-                                    
+
                                     // Extract broadcasts
-                                    let broadcasts: Vec<String> = comp.broadcasts.as_ref()
-                                        .map(|bs| bs.iter()
-                                            .flat_map(|b| b.names.clone().unwrap_or_default())
-                                            .collect())
+                                    let broadcasts: Vec<String> = comp
+                                        .broadcasts
+                                        .as_ref()
+                                        .map(|bs| {
+                                            bs.iter()
+                                                .flat_map(|b| b.names.clone().unwrap_or_default())
+                                                .collect()
+                                        })
                                         .unwrap_or_default();
-                                    
+
                                     // Extract last play and win probability
-                                    let (last_play, home_win_pct, away_win_pct) = if let Some(sit) = &comp.situation {
-                                        let lp = sit.last_play.as_ref().and_then(|p| p.text.clone());
-                                        let hwp = sit.last_play.as_ref()
-                                            .and_then(|p| p.probability.as_ref())
-                                            .and_then(|pr| pr.home_win_percentage);
-                                        let awp = sit.last_play.as_ref()
-                                            .and_then(|p| p.probability.as_ref())
-                                            .and_then(|pr| pr.away_win_percentage);
-                                        (lp, hwp, awp)
-                                    } else {
-                                        (None, None, None)
-                                    };
-                                    
+                                    let (last_play, home_win_pct, away_win_pct) =
+                                        if let Some(sit) = &comp.situation {
+                                            let lp =
+                                                sit.last_play.as_ref().and_then(|p| p.text.clone());
+                                            let hwp = sit
+                                                .last_play
+                                                .as_ref()
+                                                .and_then(|p| p.probability.as_ref())
+                                                .and_then(|pr| pr.home_win_percentage);
+                                            let awp = sit
+                                                .last_play
+                                                .as_ref()
+                                                .and_then(|p| p.probability.as_ref())
+                                                .and_then(|pr| pr.away_win_percentage);
+                                            (lp, hwp, awp)
+                                        } else {
+                                            (None, None, None)
+                                        };
+
                                     // Extract headline (for post-game recaps)
-                                    let headline = comp.headlines.as_ref()
-                                        .and_then(|hl| hl.first())
-                                        .and_then(|h| h.short_link_text.clone().or(h.description.clone()));
-                                    
+                                    let headline =
+                                        comp.headlines.as_ref().and_then(|hl| hl.first()).and_then(
+                                            |h| h.short_link_text.clone().or(h.description.clone()),
+                                        );
+
                                     // Extract series summary (for playoffs)
-                                    let series_summary = comp.series.as_ref()
-                                        .and_then(|s| s.summary.clone());
-                                    
+                                    let series_summary =
+                                        comp.series.as_ref().and_then(|s| s.summary.clone());
+
                                     // Extract top scorer (points leader from home team)
-                                    let top_scorer = h.leaders.as_ref()
-                                        .and_then(|cats| cats.iter().find(|c| c.name.as_deref() == Some("rating")))
+                                    let top_scorer = h
+                                        .leaders
+                                        .as_ref()
+                                        .and_then(|cats| {
+                                            cats.iter()
+                                                .find(|c| c.name.as_deref() == Some("rating"))
+                                        })
                                         .and_then(|cat| cat.leaders.as_ref())
                                         .and_then(|leaders| leaders.first())
                                         .map(|l| {
-                                            let name = l.athlete.as_ref()
+                                            let name = l
+                                                .athlete
+                                                .as_ref()
                                                 .and_then(|a| a.display_name.clone())
                                                 .unwrap_or_default();
                                             let value = l.display_value.clone().unwrap_or_default();
@@ -285,7 +312,19 @@ impl ScoreService {
                                         league: league_name.to_string(),
                                         start_time: event.date.clone(),
                                         status_state: event.status.status_type.state.clone(),
-                                        status_detail: event.status.status_type.short_detail.clone().unwrap_or(event.status.status_type.detail.clone().unwrap_or_default()),
+                                        status_detail: event
+                                            .status
+                                            .status_type
+                                            .short_detail
+                                            .clone()
+                                            .unwrap_or(
+                                                event
+                                                    .status
+                                                    .status_type
+                                                    .detail
+                                                    .clone()
+                                                    .unwrap_or_default(),
+                                            ),
                                         home_team: h_name,
                                         home_score: h.score.clone().unwrap_or("0".to_string()),
                                         home_abbr: h.team.abbreviation.clone().unwrap_or_default(),
@@ -298,7 +337,11 @@ impl ScoreService {
                                         away_color: a.team.color.clone(),
                                         away_record: None,
                                         away_logo: a.team.logo.clone(),
-                                        display_clock: event.status.display_clock.clone().unwrap_or_else(|| "00:00".to_string()),
+                                        display_clock: event
+                                            .status
+                                            .display_clock
+                                            .clone()
+                                            .unwrap_or_else(|| "00:00".to_string()),
                                         period: event.status.period.unwrap_or(0),
                                         venue_name,
                                         venue_city,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,17 +1,17 @@
 #[cfg(not(target_arch = "wasm32"))]
 use std::io::{self, Write};
 #[cfg(not(target_arch = "wasm32"))]
-use std::process::Command;
-#[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
+#[cfg(not(target_arch = "wasm32"))]
+use std::process::Command;
 
 /// Common locations where mpv might be installed on macOS/Linux
 #[cfg(not(target_arch = "wasm32"))]
 const MPV_CANDIDATE_PATHS: &[&str] = &[
-    "/opt/homebrew/bin/mpv",    // macOS Apple Silicon Homebrew
-    "/usr/local/bin/mpv",       // macOS Intel Homebrew / some Linux
-    "/usr/bin/mpv",             // Common system path (Linux)
-    "/snap/bin/mpv",            // Snap on Linux
+    "/opt/homebrew/bin/mpv", // macOS Apple Silicon Homebrew
+    "/usr/local/bin/mpv",    // macOS Intel Homebrew / some Linux
+    "/usr/bin/mpv",          // Common system path (Linux)
+    "/snap/bin/mpv",         // Snap on Linux
 ];
 
 /// Common locations where vlc might be installed on macOS/Linux
@@ -30,7 +30,7 @@ fn is_valid_mpv_at_path(path: &str) -> bool {
     if !p.exists() || !p.is_file() {
         return false;
     }
-    
+
     // On Unix, check if it's executable
     #[cfg(unix)]
     {
@@ -42,7 +42,7 @@ fn is_valid_mpv_at_path(path: &str) -> bool {
             }
         }
     }
-    
+
     // Verify it actually runs
     Command::new(path)
         .arg("--version")
@@ -64,14 +64,14 @@ pub fn get_mpv_path() -> Option<String> {
     {
         return Some("mpv".to_string());
     }
-    
+
     // Fallback: search common installation paths (primarily for macOS Homebrew)
     for candidate in MPV_CANDIDATE_PATHS {
         if is_valid_mpv_at_path(candidate) {
             return Some(candidate.to_string());
         }
     }
-    
+
     None
 }
 
@@ -87,7 +87,7 @@ pub fn get_vlc_path() -> Option<String> {
     {
         return Some("vlc".to_string());
     }
-    
+
     // Windows specific common paths
     if cfg!(windows) {
         let win_paths = [
@@ -100,7 +100,7 @@ pub fn get_vlc_path() -> Option<String> {
             }
         }
     }
-    
+
     // Fallback: search common installation paths
     for candidate in VLC_CANDIDATE_PATHS {
         let p = Path::new(candidate);
@@ -108,7 +108,7 @@ pub fn get_vlc_path() -> Option<String> {
             return Some(candidate.to_string());
         }
     }
-    
+
     None
 }
 
@@ -182,28 +182,28 @@ fn find_brew() -> Option<String> {
     {
         return Some("brew".to_string());
     }
-    
+
     // Check common Homebrew locations
     let candidates = [
-        "/opt/homebrew/bin/brew",    // Apple Silicon
-        "/usr/local/bin/brew",       // Intel Mac
+        "/opt/homebrew/bin/brew",              // Apple Silicon
+        "/usr/local/bin/brew",                 // Intel Mac
         "/home/linuxbrew/.linuxbrew/bin/brew", // Linux Homebrew
     ];
-    
+
     for candidate in candidates {
         let path = Path::new(candidate);
-        if path.exists() && path.is_file() {
-            if Command::new(candidate)
+        if path.exists()
+            && path.is_file()
+            && Command::new(candidate)
                 .arg("--version")
                 .output()
                 .map(|o| o.status.success())
                 .unwrap_or(false)
-            {
-                return Some(candidate.to_string());
-            }
+        {
+            return Some(candidate.to_string());
         }
     }
-    
+
     None
 }
 
@@ -212,21 +212,21 @@ fn find_brew() -> Option<String> {
 fn install_homebrew() -> Result<String, anyhow::Error> {
     println!("Installing Homebrew...");
     println!("This may take a few minutes. Please wait...");
-    
+
     // Run the official Homebrew installer script with NONINTERACTIVE flag
     let status = Command::new("/bin/bash")
-        .args(&[
+        .args([
             "-c",
             "NONINTERACTIVE=1 /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
         ])
         .status()?;
-    
+
     if !status.success() {
         return Err(anyhow::anyhow!(
             "Failed to install Homebrew. Please install manually from https://brew.sh/"
         ));
     }
-    
+
     // Find brew after installation
     if let Some(brew_path) = find_brew() {
         println!("✓ Homebrew installed successfully.");
@@ -252,25 +252,23 @@ fn install_mpv_macos() -> Result<(), anyhow::Error> {
             install_homebrew()?
         }
     };
-    
+
     println!("Installing mpv via Homebrew...");
     println!("Running: {} install mpv", brew_path);
-    
-    let status = Command::new(&brew_path)
-        .args(&["install", "mpv"])
-        .status()?;
+
+    let status = Command::new(&brew_path).args(["install", "mpv"]).status()?;
 
     if status.success() {
         println!("✓ mpv installed successfully via Homebrew.");
         return Ok(());
     }
-    
+
     // Try cask as fallback
     println!("Formula install failed, trying cask...");
     let status_cask = Command::new(&brew_path)
-        .args(&["install", "--cask", "mpv"])
+        .args(["install", "--cask", "mpv"])
         .status()?;
-    
+
     if status_cask.success() {
         println!("✓ mpv installed successfully via Homebrew Cask.");
         Ok(())
@@ -287,7 +285,7 @@ fn install_mpv_windows() -> Result<(), anyhow::Error> {
     // Try installing specific ID first
     println!("Running: winget install -e --id \"9P3JFR0CLLL6\" --accept-source-agreements --accept-package-agreements");
     let status = Command::new("winget")
-        .args(&[
+        .args([
             "install",
             "-e",
             "--id",
@@ -306,7 +304,7 @@ fn install_mpv_windows() -> Result<(), anyhow::Error> {
 
     println!("Specific ID failed, trying generic 'mpv'...");
     let status_generic = Command::new("winget")
-        .args(&[
+        .args([
             "install",
             "-e",
             "mpv",
@@ -329,10 +327,10 @@ fn install_vlc_macos() -> Result<(), anyhow::Error> {
         Some(path) => path,
         None => install_homebrew()?,
     };
-    
+
     println!("Installing vlc via Homebrew Cask...");
     let status = Command::new(&brew_path)
-        .args(&["install", "--cask", "vlc"])
+        .args(["install", "--cask", "vlc"])
         .status()?;
 
     if status.success() {
@@ -347,7 +345,7 @@ fn install_vlc_macos() -> Result<(), anyhow::Error> {
 fn install_vlc_windows() -> Result<(), anyhow::Error> {
     println!("Running: winget install -e --id VideoLAN.VLC --accept-source-agreements --accept-package-agreements");
     let status = Command::new("winget")
-        .args(&[
+        .args([
             "install",
             "-e",
             "--id",
@@ -367,11 +365,8 @@ fn install_vlc_windows() -> Result<(), anyhow::Error> {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn is_newer_version(current: &str, tag: &str) -> bool {
-    let parse_version = |s: &str| -> Vec<u32> {
-        s.split('.')
-            .filter_map(|p| p.parse::<u32>().ok())
-            .collect()
-    };
+    let parse_version =
+        |s: &str| -> Vec<u32> { s.split('.').filter_map(|p| p.parse::<u32>().ok()).collect() };
 
     let cur_parts = parse_version(current);
     let tag_parts = parse_version(tag);
@@ -379,7 +374,7 @@ fn is_newer_version(current: &str, tag: &str) -> bool {
     for i in 0..std::cmp::max(cur_parts.len(), tag_parts.len()) {
         let cur = cur_parts.get(i).unwrap_or(&0);
         let tgt = tag_parts.get(i).unwrap_or(&0);
-        
+
         if tgt > cur {
             return true;
         } else if tgt < cur {
@@ -390,7 +385,10 @@ fn is_newer_version(current: &str, tag: &str) -> bool {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn check_for_updates(tx: tokio::sync::mpsc::Sender<crate::app::AsyncAction>, manual: bool) {
+pub async fn check_for_updates(
+    tx: tokio::sync::mpsc::Sender<crate::app::AsyncAction>,
+    manual: bool,
+) {
     let current_version = env!("CARGO_PKG_VERSION");
     let client = reqwest::Client::builder()
         .user_agent("matrix-iptv-cli-updater")
@@ -400,21 +398,28 @@ pub async fn check_for_updates(tx: tokio::sync::mpsc::Sender<crate::app::AsyncAc
 
     // Use a GET request to the latest release to check the tag
     // GitHub redirects /latest to the specific tag URL
-    if let Ok(resp) = client.get("https://github.com/officebeats/matrix-iptv/releases/latest")
+    if let Ok(resp) = client
+        .get("https://github.com/officebeats/matrix-iptv/releases/latest")
         .send()
-        .await 
+        .await
     {
         let final_url = resp.url().to_string();
         // URL is likely https://github.com/officebeats/matrix-iptv/releases/tag/v3.0.9
         if let Some(tag) = final_url.split("/tag/").last() {
             let tag = tag.trim_start_matches('v');
             if is_newer_version(current_version, tag) {
-                let _ = tx.send(crate::app::AsyncAction::UpdateAvailable(tag.to_string())).await;
+                let _ = tx
+                    .send(crate::app::AsyncAction::UpdateAvailable(tag.to_string()))
+                    .await;
             } else if manual {
                 let _ = tx.send(crate::app::AsyncAction::NoUpdateFound).await;
             }
         }
     } else if manual {
-        let _ = tx.send(crate::app::AsyncAction::Error("Failed to check for updates. Please check your connection.".to_string())).await;
+        let _ = tx
+            .send(crate::app::AsyncAction::Error(
+                "Failed to check for updates. Please check your connection.".to_string(),
+            ))
+            .await;
     }
 }

--- a/src/sports.rs
+++ b/src/sports.rs
@@ -1,7 +1,6 @@
+use anyhow::Result;
 use ratatui::style::Color;
 use serde::{Deserialize, Serialize};
-use anyhow::Result;
-
 
 /// Returns the primary color for a team based on its name or abbreviation.
 pub fn get_team_color(name: &str) -> Color {
@@ -299,7 +298,7 @@ fn lighten_color(color: Color) -> Color {
         Color::Rgb(r, g, b) => {
             // Calculate luminance (using rough approximation)
             let luminance = (r as f32 * 0.299 + g as f32 * 0.587 + b as f32 * 0.114) / 255.0;
-            
+
             // If color is too dark (luminance < 0.5), lighten it (increased from 0.4)
             if luminance < 0.5 {
                 let boost = 1.7 + (0.5 - luminance); // Increased boost by ~15%
@@ -332,11 +331,33 @@ pub fn get_team_color_with_fallback(name: &str, is_home: bool) -> Color {
 pub fn is_generic_label(name: &str) -> bool {
     let name = name.to_uppercase();
     let generics = [
-        "MNF", "SNF", "TNF", "NFL LIVE", "NFL MEDIA", "NFL NETWORK", "NFL PACKAGE",
-        "NBA TV", "NBA PACKAGE", "NBA GAMETIME", "MLB TV", "MLB PACKAGE",
-        "EVENT ONLY", "LIVE NOW", "REPLAY", "FULL REPLAY", "DIRECT TV",
-        "SPORTS", "FOOTBALL", "BASKETBALL", "BASEBALL", "HOCKEY", "SOCCER",
-        "LIVE SPORTS", "GAME PASS", "REDZONE", "NFL REDZONE"
+        "MNF",
+        "SNF",
+        "TNF",
+        "NFL LIVE",
+        "NFL MEDIA",
+        "NFL NETWORK",
+        "NFL PACKAGE",
+        "NBA TV",
+        "NBA PACKAGE",
+        "NBA GAMETIME",
+        "MLB TV",
+        "MLB PACKAGE",
+        "EVENT ONLY",
+        "LIVE NOW",
+        "REPLAY",
+        "FULL REPLAY",
+        "DIRECT TV",
+        "SPORTS",
+        "FOOTBALL",
+        "BASKETBALL",
+        "BASEBALL",
+        "HOCKEY",
+        "SOCCER",
+        "LIVE SPORTS",
+        "GAME PASS",
+        "REDZONE",
+        "NFL REDZONE",
     ];
 
     for g in generics {
@@ -375,7 +396,7 @@ pub fn parse_sports_event(display_name: &str) -> Option<SportsEvent> {
         let team1_abbr = caps.get(2).map(|m| m.as_str().trim().to_string());
         let team2 = caps.get(3)?.as_str().trim().to_string();
         let team2_abbr = caps.get(4).map(|m| m.as_str().trim().to_string());
-        
+
         // Debug prints
         if display_name.contains("start:2025-12-21") {
             println!("DEBUG: display_name: {:?}", display_name);

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,13 +1,15 @@
+use ratatui::layout::Rect;
+use ratatui::widgets::ListState;
 use std::collections::HashMap;
 use std::sync::Arc;
-use ratatui::widgets::ListState;
-use ratatui::layout::Rect;
 
-use crate::api::{Category, IptvClient, Stream, UserInfo, ServerInfo, SeriesEpisode, SeriesInfo, VodInfo};
+use crate::api::{
+    Category, IptvClient, SeriesEpisode, SeriesInfo, ServerInfo, Stream, UserInfo, VodInfo,
+};
+use crate::app::{CurrentScreen, MatrixColumn, Pane};
 use crate::errors::LoadingProgress;
-use crate::app::{CurrentScreen, Pane, MatrixColumn};
-use crate::sports::{StreamedMatch, StreamedStream};
 use crate::scores::ScoreGame;
+use crate::sports::{StreamedMatch, StreamedStream};
 
 /// Type of content for filtering and management
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -75,12 +77,12 @@ impl SessionState {
     pub fn new() -> Self {
         Self::default()
     }
-    
+
     /// Check if session is connected
     pub fn is_connected(&self) -> bool {
         self.current_client.is_some()
     }
-    
+
     /// Clear session data (logout)
     pub fn clear(&mut self) {
         self.current_client = None;
@@ -102,6 +104,7 @@ impl SessionState {
 
 /// Content state for categories and streams
 /// Used for Live channels, VOD movies, and Series
+#[derive(Default)]
 pub struct ContentState {
     /// All categories (unfiltered)
     pub all_categories: Vec<Arc<Category>>,
@@ -125,28 +128,11 @@ pub struct ContentState {
     pub epg_cache: HashMap<String, String>,
 }
 
-impl Default for ContentState {
-    fn default() -> Self {
-        Self {
-            all_categories: Vec::new(),
-            categories: Vec::new(),
-            selected_category_index: 0,
-            category_list_state: ListState::default(),
-            all_streams: Vec::new(),
-            streams: Vec::new(),
-            selected_stream_index: 0,
-            stream_list_state: ListState::default(),
-            category_channel_counts: HashMap::new(),
-            epg_cache: HashMap::new(),
-        }
-    }
-}
-
 impl ContentState {
     pub fn new() -> Self {
         Self::default()
     }
-    
+
     /// Select a category by index
     pub fn select_category(&mut self, index: usize) {
         self.selected_category_index = index;
@@ -154,7 +140,7 @@ impl ContentState {
             self.category_list_state.select(Some(index));
         }
     }
-    
+
     /// Select a stream by index
     pub fn select_stream(&mut self, index: usize) {
         self.selected_stream_index = index;
@@ -162,17 +148,17 @@ impl ContentState {
             self.stream_list_state.select(Some(index));
         }
     }
-    
+
     /// Get the selected category
     pub fn selected_category(&self) -> Option<&Arc<Category>> {
         self.categories.get(self.selected_category_index)
     }
-    
+
     /// Get the selected stream
     pub fn selected_stream(&self) -> Option<&Arc<Stream>> {
         self.streams.get(self.selected_stream_index)
     }
-    
+
     /// Clear all content
     pub fn clear(&mut self) {
         self.all_categories.clear();
@@ -184,7 +170,7 @@ impl ContentState {
         self.category_channel_counts.clear();
         self.epg_cache.clear();
     }
-    
+
     /// Check if content is loaded
     pub fn has_content(&self) -> bool {
         !self.all_categories.is_empty() || !self.all_streams.is_empty()
@@ -192,6 +178,7 @@ impl ContentState {
 }
 
 /// Series state extending ContentState with episode handling
+#[derive(Default)]
 pub struct SeriesState {
     /// Base content state
     pub content: ContentState,
@@ -205,23 +192,11 @@ pub struct SeriesState {
     pub current_series_info: Option<SeriesInfo>,
 }
 
-impl Default for SeriesState {
-    fn default() -> Self {
-        Self {
-            content: ContentState::default(),
-            series_episodes: Vec::new(),
-            selected_series_episode_index: 0,
-            series_episode_list_state: ListState::default(),
-            current_series_info: None,
-        }
-    }
-}
-
 impl SeriesState {
     pub fn new() -> Self {
         Self::default()
     }
-    
+
     /// Select an episode by index
     pub fn select_episode(&mut self, index: usize) {
         self.selected_series_episode_index = index;
@@ -229,12 +204,12 @@ impl SeriesState {
             self.series_episode_list_state.select(Some(index));
         }
     }
-    
+
     /// Get the selected episode
     pub fn selected_episode(&self) -> Option<&SeriesEpisode> {
         self.series_episodes.get(self.selected_series_episode_index)
     }
-    
+
     /// Clear series-specific data
     pub fn clear_series(&mut self) {
         self.series_episodes.clear();
@@ -244,20 +219,12 @@ impl SeriesState {
 }
 
 /// VOD state with movie info
+#[derive(Default)]
 pub struct VodState {
     /// Base content state
     pub content: ContentState,
     /// Selected VOD metadata
     pub current_vod_info: Option<VodInfo>,
-}
-
-impl Default for VodState {
-    fn default() -> Self {
-        Self {
-            content: ContentState::default(),
-            current_vod_info: None,
-        }
-    }
 }
 
 impl VodState {
@@ -307,7 +274,7 @@ impl LoginFormState {
     pub fn new() -> Self {
         Self::default()
     }
-    
+
     /// Clear form
     pub fn clear(&mut self) {
         self.input_name.reset();
@@ -381,13 +348,13 @@ impl UiState {
     pub fn new() -> Self {
         Self::default()
     }
-    
+
     /// Navigate to a screen, saving history
     pub fn navigate_to(&mut self, screen: CurrentScreen) {
         self.previous_screen = Some(self.current_screen.clone());
         self.current_screen = screen;
     }
-    
+
     /// Go back to previous screen
     pub fn go_back(&mut self) {
         if let Some(prev) = self.previous_screen.take() {
@@ -426,6 +393,7 @@ impl SportsState {
 }
 
 /// Matrix rain animation state
+#[derive(Default)]
 pub struct MatrixRainState {
     /// Animation active
     pub active: bool,
@@ -440,18 +408,6 @@ pub struct MatrixRainState {
     pub columns: Vec<MatrixColumn>,
     /// Logo pixel activation
     pub logo_hits: Vec<bool>,
-}
-
-impl Default for MatrixRainState {
-    fn default() -> Self {
-        Self {
-            active: false,
-            start_time: None,
-            screensaver_mode: false,
-            columns: Vec::new(),
-            logo_hits: Vec::new(),
-        }
-    }
 }
 
 impl MatrixRainState {
@@ -479,7 +435,7 @@ impl SearchState {
     pub fn new() -> Self {
         Self::default()
     }
-    
+
     /// Clear search
     pub fn clear(&mut self) {
         self.query.clear();

--- a/src/ui/colors.rs
+++ b/src/ui/colors.rs
@@ -17,11 +17,11 @@ pub const DARK_GREEN: Color = Color::Rgb(0, 120, 30);
 pub const HIGHLIGHT_BG: Color = Color::Rgb(0, 40, 10);
 
 // Text hierarchy — all must be clearly visible on pure black
-pub const BRIGHT_GREEN: Color = Color::White;     // Primary text (white for max contrast)
-pub const TEXT_PRIMARY: Color = Color::White;      // Main content text
+pub const BRIGHT_GREEN: Color = Color::White; // Primary text (white for max contrast)
+pub const TEXT_PRIMARY: Color = Color::White; // Main content text
 pub const TEXT_SECONDARY: Color = Color::Rgb(200, 200, 200); // Secondary labels — bright enough on black
 pub const TEXT_DIM: Color = Color::Rgb(180, 180, 180); // Dimmer text — still clearly white-ish
-pub const TEXT_MUTED: Color = Color::Rgb(140, 140, 140);  // Structural separators — visible
+pub const TEXT_MUTED: Color = Color::Rgb(140, 140, 140); // Structural separators — visible
 
 // Status colors (restrained — only for meaning)
 pub const STATUS_LIVE: Color = Color::Rgb(255, 100, 100);

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -1,14 +1,16 @@
+use crate::parser::{ContentType, Quality};
+use crate::sports::SportsEvent;
+use crate::ui::colors::{
+    MATRIX_GREEN, MODERN_BG, SOFT_GREEN, TEXT_DIM, TEXT_PRIMARY, TEXT_SECONDARY,
+};
 use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     text::Span,
     Frame,
 };
-use crate::parser::{Quality, ContentType};
-use crate::ui::colors::{MATRIX_GREEN, SOFT_GREEN, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_DIM, MODERN_BG};
-use crate::sports::SportsEvent;
 
-use crate::ui::utils::{scrub_emojis};
+use crate::ui::utils::scrub_emojis;
 
 pub fn stylize_channel_name(
     name: &str,
@@ -21,20 +23,20 @@ pub fn stylize_channel_name(
 ) -> (Vec<Span<'static>>, Option<&'static str>) {
     let clean_name = scrub_emojis(name);
     let mut spans = Vec::new();
-    
+
     let (ppv_color, vip_color, raw_color, hd_color, fhd_color, uhd_color, fps_color) = if is_ended {
         let dim = TEXT_DIM;
         (dim, dim, dim, dim, dim, dim, dim)
     } else {
         // Use Quality::color() values for distinct quality coding
         (
-            Color::Rgb(255, 105, 180),        // PPV: pink
-            Color::Rgb(255, 200, 80),          // VIP: gold
-            MATRIX_GREEN,                       // RAW: green
-            Color::Rgb(0, 255, 255),            // HD: cyan  (matches Quality::HD)
-            Color::Rgb(57, 255, 20),            // FHD: neon green (matches Quality::FHD)
-            Color::Rgb(255, 0, 255),            // 4K/UHD: magenta (matches Quality::UHD4K)
-            Color::Rgb(255, 200, 80),           // FPS: gold
+            Color::Rgb(255, 105, 180), // PPV: pink
+            Color::Rgb(255, 200, 80),  // VIP: gold
+            MATRIX_GREEN,              // RAW: green
+            Color::Rgb(0, 255, 255),   // HD: cyan  (matches Quality::HD)
+            Color::Rgb(57, 255, 20),   // FHD: neon green (matches Quality::FHD)
+            Color::Rgb(255, 0, 255),   // 4K/UHD: magenta (matches Quality::UHD4K)
+            Color::Rgb(255, 200, 80),  // FPS: gold
         )
     };
 
@@ -53,56 +55,77 @@ pub fn stylize_channel_name(
     if let Some(event) = sports_event {
         let words: Vec<&str> = name.split_whitespace().collect();
         for word in words {
-             let check = word.replace(&['(', ')', '[', ']', '{', '}', ':'][..], "").trim().to_uppercase();
-             detected_sport_icon = match check.as_str() {
-                 "NBA" => "",
-                 "NFL" => "",
-                 "MLB" => "",
-                 "NHL" => "",
-                 "UFC" | "MMA" => "",
-                 "F1" | "NASCAR" | "RACING" => "",
-                 "GOLF" | "PGA" => "",
-                 "TENNIS" | "ATP" | "WTA" => "",
-                 "SOCCER" | "FOOTBALL" | "LEAGUE" | "BUNDESLIGA" | "LALIGA" | "PREMIER" | "UEFA" | "FIFA" => "",
-                 "CRICKET" => "",
-                 "RUGBY" => "",
-                 _ => detected_sport_icon,
-             };
-             if !detected_sport_icon.is_empty() { break; }
+            let check = word
+                .replace(&['(', ')', '[', ']', '{', '}', ':'][..], "")
+                .trim()
+                .to_uppercase();
+            detected_sport_icon = match check.as_str() {
+                "NBA" => "",
+                "NFL" => "",
+                "MLB" => "",
+                "NHL" => "",
+                "UFC" | "MMA" => "",
+                "F1" | "NASCAR" | "RACING" => "",
+                "GOLF" | "PGA" => "",
+                "TENNIS" | "ATP" | "WTA" => "",
+                "SOCCER" | "FOOTBALL" | "LEAGUE" | "BUNDESLIGA" | "LALIGA" | "PREMIER" | "UEFA"
+                | "FIFA" => "",
+                "CRICKET" => "",
+                "RUGBY" => "",
+                _ => detected_sport_icon,
+            };
+            if !detected_sport_icon.is_empty() {
+                break;
+            }
         }
 
         // Sports matchup: Home green, Away white
-        spans.push(Span::styled(format!("{}", event.team1), base_style.fg(MATRIX_GREEN)));
+        spans.push(Span::styled(
+            event.team1.to_string(),
+            base_style.fg(MATRIX_GREEN),
+        ));
         spans.push(Span::styled(" vs ", Style::default().fg(TEXT_SECONDARY)));
-        spans.push(Span::styled(format!("{}", event.team2), base_style.fg(TEXT_PRIMARY)));
-        
+        spans.push(Span::styled(
+            event.team2.to_string(),
+            base_style.fg(TEXT_PRIMARY),
+        ));
     } else {
         let words: Vec<&str> = clean_name.split_whitespace().collect();
         for (i, word) in words.iter().enumerate() {
             if i > 0 {
                 spans.push(Span::raw(" "));
             }
-            
+
             let sub_parts: Vec<&str> = word.split('/').collect();
             for (j, sub) in sub_parts.iter().enumerate() {
                 if j > 0 {
                     spans.push(Span::styled("/", base_style));
                 }
 
-                let upper = sub.replace(&['(', ')', '[', ']', '{', '}', ':'][..], "").trim().to_uppercase();
+                let upper = sub
+                    .replace(&['(', ')', '[', ']', '{', '}', ':'][..], "")
+                    .trim()
+                    .to_uppercase();
                 let check_word = upper.as_str();
 
                 match check_word {
-                    "MULTI-SUB" | "MULTISUB" | "MULTI-AUDIO" | "MULTIAUDIO" | "MULTILANG" | "MULTI-LANG" | "MULTI" => {
+                    "MULTI-SUB" | "MULTISUB" | "MULTI-AUDIO" | "MULTIAUDIO" | "MULTILANG"
+                    | "MULTI-LANG" | "MULTI" => {
                         continue;
                     }
                     "PPV" => {
                         found_ppv = true;
-                        spans.push(Span::styled("PPV", base_style.fg(ppv_color).add_modifier(Modifier::BOLD)));
+                        spans.push(Span::styled(
+                            "PPV",
+                            base_style.fg(ppv_color).add_modifier(Modifier::BOLD),
+                        ));
                     }
                     "VIP" => {
                         found_vip = true;
-                        spans.push(Span::styled("VIP", base_style.fg(vip_color).add_modifier(Modifier::BOLD)));
+                        spans.push(Span::styled(
+                            "VIP",
+                            base_style.fg(vip_color).add_modifier(Modifier::BOLD),
+                        ));
                     }
                     "RAW" => {
                         spans.push(Span::styled("RAW", base_style.fg(raw_color)));
@@ -117,16 +140,28 @@ pub fn stylize_channel_name(
                     }
                     val if ["4K", "UHD", "HEVC"].contains(&val) => {
                         found_4k = true;
-                        spans.push(Span::styled(format!("{}", val), base_style.fg(uhd_color).add_modifier(Modifier::BOLD)));
+                        spans.push(Span::styled(
+                            val.to_string(),
+                            base_style.fg(uhd_color).add_modifier(Modifier::BOLD),
+                        ));
                     }
                     val if val.ends_with("FPS") && val.len() > 3 => {
-                        spans.push(Span::styled(format!("{}", val.to_lowercase()), base_style.fg(fps_color)));
+                        spans.push(Span::styled(
+                            val.to_lowercase().to_string(),
+                            base_style.fg(fps_color),
+                        ));
                     }
                     _ => {
-                        let is_year = ((sub.starts_with('(') && sub.ends_with(')')) || (sub.starts_with('[') && sub.ends_with(']'))) && sub.len() == 6 && sub[1..5].chars().all(|c| c.is_digit(10));
-                        
+                        let is_year = ((sub.starts_with('(') && sub.ends_with(')'))
+                            || (sub.starts_with('[') && sub.ends_with(']')))
+                            && sub.len() == 6
+                            && sub[1..5].chars().all(|c| c.is_ascii_digit());
+
                         if is_year {
-                            spans.push(Span::styled(format!("{}", sub), Style::default().fg(TEXT_SECONDARY)));
+                            spans.push(Span::styled(
+                                sub.to_string(),
+                                Style::default().fg(TEXT_SECONDARY),
+                            ));
                         } else {
                             if detected_sport_icon.is_empty() {
                                 detected_sport_icon = match check_word {
@@ -138,14 +173,15 @@ pub fn stylize_channel_name(
                                     "F1" | "NASCAR" | "RACING" => "",
                                     "GOLF" | "PGA" => "",
                                     "TENNIS" | "ATP" | "WTA" => "",
-                                    "SOCCER" | "FOOTBALL" | "LEAGUE" | "BUNDESLIGA" | "LALIGA" | "PREMIER" | "UEFA" | "FIFA" => "",
+                                    "SOCCER" | "FOOTBALL" | "LEAGUE" | "BUNDESLIGA" | "LALIGA"
+                                    | "PREMIER" | "UEFA" | "FIFA" => "",
                                     "CRICKET" => "",
                                     "RUGBY" => "",
                                     _ => "",
                                 };
                             }
-                            
-                            spans.push(Span::styled(format!("{}", sub), base_style));
+
+                            spans.push(Span::styled(sub.to_string(), base_style));
                         }
                     }
                 }
@@ -154,26 +190,39 @@ pub fn stylize_channel_name(
     }
 
     if is_vip && !found_vip {
-         spans.push(Span::styled(" VIP", base_style.fg(vip_color).add_modifier(Modifier::BOLD)));
+        spans.push(Span::styled(
+            " VIP",
+            base_style.fg(vip_color).add_modifier(Modifier::BOLD),
+        ));
     }
-    
+
     if let Some(ct) = content_type {
         if ct == ContentType::PPV && !found_ppv {
-             spans.push(Span::styled(" PPV", base_style.fg(ppv_color).add_modifier(Modifier::BOLD)));
-        }
-    }
-    
-    if let Some(q) = quality {
-        if (q == Quality::UHD4K) && !found_4k {
-             spans.push(Span::styled(" 4K", base_style.fg(fhd_color).add_modifier(Modifier::BOLD)));
-        } else if (q == Quality::FHD) && !found_fhd {
-             spans.push(Span::styled(" FHD", base_style.fg(fhd_color)));
-        } else if (q == Quality::HD) && !found_hd {
-             spans.push(Span::styled(" HD", base_style.fg(hd_color)));
+            spans.push(Span::styled(
+                " PPV",
+                base_style.fg(ppv_color).add_modifier(Modifier::BOLD),
+            ));
         }
     }
 
-    let icon_ret = if detected_sport_icon.is_empty() { None } else { Some(detected_sport_icon) };
+    if let Some(q) = quality {
+        if (q == Quality::UHD4K) && !found_4k {
+            spans.push(Span::styled(
+                " 4K",
+                base_style.fg(fhd_color).add_modifier(Modifier::BOLD),
+            ));
+        } else if (q == Quality::FHD) && !found_fhd {
+            spans.push(Span::styled(" FHD", base_style.fg(fhd_color)));
+        } else if (q == Quality::HD) && !found_hd {
+            spans.push(Span::styled(" HD", base_style.fg(hd_color)));
+        }
+    }
+
+    let icon_ret = if detected_sport_icon.is_empty() {
+        None
+    } else {
+        Some(detected_sport_icon)
+    };
     (spans, icon_ret)
 }
 
@@ -183,13 +232,23 @@ pub fn render_matrix_box(f: &mut Frame, area: Rect, title: &str, border_color: C
 }
 
 /// Bordered panel with active state (DOUBLE borders for active, ROUNDED for inactive).
-pub fn render_matrix_box_active(f: &mut Frame, area: Rect, title: &str, border_color: Color, is_active: bool) -> Rect {
+pub fn render_matrix_box_active(
+    f: &mut Frame,
+    area: Rect,
+    title: &str,
+    border_color: Color,
+    is_active: bool,
+) -> Rect {
     use ratatui::prelude::*;
-    use ratatui::widgets::{Block, Borders};
     use ratatui::symbols::border;
+    use ratatui::widgets::{Block, Borders};
 
     let clean_title = title.trim().trim_matches('/');
-    let border_set = if is_active { border::DOUBLE } else { border::ROUNDED };
+    let border_set = if is_active {
+        border::DOUBLE
+    } else {
+        border::ROUNDED
+    };
 
     let block = if !clean_title.is_empty() {
         Block::default()
@@ -198,9 +257,24 @@ pub fn render_matrix_box_active(f: &mut Frame, area: Rect, title: &str, border_c
             .border_style(Style::default().fg(border_color))
             .bg(MODERN_BG)
             .title(Line::from(vec![
-                Span::styled(if is_active { "═ " } else { "─ " }, Style::default().fg(border_color)),
-                Span::styled(clean_title, Style::default().fg(if is_active { MATRIX_GREEN } else { border_color }).add_modifier(Modifier::BOLD)),
-                Span::styled(if is_active { " ═" } else { " ─" }, Style::default().fg(border_color)),
+                Span::styled(
+                    if is_active { "═ " } else { "─ " },
+                    Style::default().fg(border_color),
+                ),
+                Span::styled(
+                    clean_title,
+                    Style::default()
+                        .fg(if is_active {
+                            MATRIX_GREEN
+                        } else {
+                            border_color
+                        })
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    if is_active { " ═" } else { " ─" },
+                    Style::default().fg(border_color),
+                ),
             ]))
             .title_alignment(Alignment::Center)
     } else {
@@ -221,4 +295,3 @@ pub fn render_composite_block(f: &mut Frame, area: Rect, title: Option<&str>) ->
     let t = title.unwrap_or("");
     render_matrix_box(f, area, t, SOFT_GREEN)
 }
-

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -37,7 +37,7 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
             hint!("e", "edit");
             hint!("d", "del");
             hint!("s", "sports");
-            hint!("m", "filter");
+            hint!("m", "mode");
             hint!("x", "settings");
             hint!("?", "help");
         }
@@ -50,9 +50,7 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
                 hint!("enter", "edit");
             }
         }
-        CurrentScreen::Categories | CurrentScreen::Streams |
-        CurrentScreen::VodCategories | CurrentScreen::VodStreams |
-        CurrentScreen::SeriesCategories | CurrentScreen::SeriesStreams => {
+        CurrentScreen::Categories | CurrentScreen::Streams => {
             if app.search_mode {
                 hint!("esc", "cancel");
                 hint!("enter", "done");
@@ -63,21 +61,91 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
                         hint!("enter", "select");
                         hint!("/", "search");
                         hint!("tab", "streams");
+                        hint!("v", "fav");
+                        hint!("PgDn", "page");
                         hint!("g", "grid/list");
+                        hint!("G", "groups");
                     }
                     crate::app::Pane::Streams => {
                         hint!("esc", "back");
                         hint!("enter", "play");
                         hint!("/", "search");
                         hint!("v", "fav");
-                        hint!("i", "info");
-                        hint!("g", "groups");
+                        hint!("g", "add group");
+                        hint!("G", "groups");
                         hint!("?", "help");
+                    }
+                    crate::app::Pane::Episodes => {}
+                }
+            }
+        }
+        CurrentScreen::VodCategories => {
+            if app.search_mode {
+                hint!("esc", "cancel");
+                hint!("enter", "done");
+            } else {
+                hint!("esc", "back");
+                hint!("enter", "select");
+                hint!("/", "search");
+                hint!("PgDn", "page");
+                hint!("g", "grid/list");
+                hint!("G", "bottom");
+            }
+        }
+        CurrentScreen::VodStreams => {
+            if app.search_mode {
+                hint!("esc", "cancel");
+                hint!("enter", "done");
+            } else {
+                hint!("esc", "back");
+                hint!("enter", "play");
+                hint!("/", "search");
+                hint!("PgDn", "page");
+                hint!("g", "top");
+                hint!("G", "bottom");
+            }
+        }
+        CurrentScreen::SeriesCategories => {
+            if app.search_mode {
+                hint!("esc", "cancel");
+                hint!("enter", "done");
+            } else {
+                hint!("esc", "back");
+                hint!("enter", "select");
+                hint!("/", "search");
+                hint!("PgDn", "page");
+                hint!("g", "grid/list");
+                hint!("G", "bottom");
+            }
+        }
+        CurrentScreen::SeriesStreams => {
+            if app.search_mode {
+                hint!("esc", "cancel");
+                hint!("enter", "done");
+            } else {
+                match app.active_pane {
+                    crate::app::Pane::Categories => {
+                        hint!("esc", "back");
+                        hint!("enter", "select");
+                        hint!("/", "search");
+                        hint!("PgDn", "page");
+                        hint!("g", "grid/list");
+                        hint!("G", "bottom");
+                    }
+                    crate::app::Pane::Streams => {
+                        hint!("esc", "back");
+                        hint!("enter", "episodes");
+                        hint!("/", "search");
+                        hint!("PgDn", "page");
+                        hint!("Home", "top");
+                        hint!("End", "bottom");
                     }
                     crate::app::Pane::Episodes => {
                         hint!("esc", "back");
                         hint!("enter", "play");
-                        hint!("tab", "series");
+                        hint!("PgDn", "page");
+                        hint!("Home", "top");
+                        hint!("End", "bottom");
                     }
                 }
             }
@@ -114,6 +182,12 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
             hint!("enter", "open");
             hint!("↑↓", "navigate");
             hint!("R", "refresh");
+        }
+        CurrentScreen::GroupManagement => {
+            hint!("esc", "back");
+            hint!("n", "new");
+            hint!("d", "del");
+            hint!("enter", "back");
         }
         _ => {
             hint!("q", "quit");

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -62,7 +62,6 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
                         hint!("/", "search");
                         hint!("tab", "streams");
                         hint!("v", "fav");
-                        hint!("PgDn", "page");
                         hint!("g", "grid/list");
                         hint!("G", "groups");
                     }
@@ -87,7 +86,6 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
                 hint!("esc", "back");
                 hint!("enter", "select");
                 hint!("/", "search");
-                hint!("PgDn", "page");
                 hint!("g", "grid/list");
                 hint!("G", "bottom");
             }
@@ -100,7 +98,6 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
                 hint!("esc", "back");
                 hint!("enter", "play");
                 hint!("/", "search");
-                hint!("PgDn", "page");
                 hint!("g", "top");
                 hint!("G", "bottom");
             }
@@ -113,7 +110,6 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
                 hint!("esc", "back");
                 hint!("enter", "select");
                 hint!("/", "search");
-                hint!("PgDn", "page");
                 hint!("g", "grid/list");
                 hint!("G", "bottom");
             }
@@ -128,7 +124,6 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
                         hint!("esc", "back");
                         hint!("enter", "select");
                         hint!("/", "search");
-                        hint!("PgDn", "page");
                         hint!("g", "grid/list");
                         hint!("G", "bottom");
                     }
@@ -136,14 +131,12 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
                         hint!("esc", "back");
                         hint!("enter", "episodes");
                         hint!("/", "search");
-                        hint!("PgDn", "page");
                         hint!("Home", "top");
                         hint!("End", "bottom");
                     }
                     crate::app::Pane::Episodes => {
                         hint!("esc", "back");
                         hint!("enter", "play");
-                        hint!("PgDn", "page");
                         hint!("Home", "top");
                         hint!("End", "bottom");
                     }

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -1,3 +1,5 @@
+use crate::app::{App, CurrentScreen, InputMode, SettingsState};
+use crate::ui::colors::{MATRIX_GREEN, MODERN_BG, SOFT_GREEN, TEXT_DIM, TEXT_SECONDARY};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Style, Stylize},
@@ -5,8 +7,6 @@ use ratatui::{
     widgets::Paragraph,
     Frame,
 };
-use crate::app::{App, CurrentScreen, InputMode, SettingsState};
-use crate::ui::colors::{MATRIX_GREEN, SOFT_GREEN, TEXT_DIM, TEXT_SECONDARY, MODERN_BG};
 
 pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
     let key_style = Style::default().fg(MATRIX_GREEN);
@@ -143,20 +143,18 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
                 }
             }
         }
-        CurrentScreen::Settings => {
-            match app.settings_state {
-                SettingsState::ManageAccounts => {
-                    hint!("esc", "back");
-                    hint!("a", "add");
-                    hint!("d", "del");
-                    hint!("enter", "edit");
-                }
-                _ => {
-                    hint!("esc", "back");
-                    hint!("enter", "select");
-                }
+        CurrentScreen::Settings => match app.settings_state {
+            SettingsState::ManageAccounts => {
+                hint!("esc", "back");
+                hint!("a", "add");
+                hint!("d", "del");
+                hint!("enter", "edit");
             }
-        }
+            _ => {
+                hint!("esc", "back");
+                hint!("enter", "select");
+            }
+        },
         CurrentScreen::TimezoneSettings => {
             hint!("esc", "back");
             hint!("enter", "select");
@@ -191,9 +189,12 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
     // Right-aligned page info (JiraTUI-style)
     let mut right_spans: Vec<Span> = Vec::new();
     match app.current_screen {
-        CurrentScreen::Categories | CurrentScreen::Streams |
-        CurrentScreen::VodCategories | CurrentScreen::VodStreams |
-        CurrentScreen::SeriesCategories | CurrentScreen::SeriesStreams => {
+        CurrentScreen::Categories
+        | CurrentScreen::Streams
+        | CurrentScreen::VodCategories
+        | CurrentScreen::VodStreams
+        | CurrentScreen::SeriesCategories
+        | CurrentScreen::SeriesStreams => {
             if !app.streams.is_empty() && app.active_pane == crate::app::Pane::Streams {
                 let page = app.selected_stream_index + 1;
                 let total = app.streams.len();
@@ -207,9 +208,9 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
     }
 
     // Use bordered bottom bar
-    use ratatui::widgets::{Block, Borders};
     use ratatui::symbols::border;
-    
+    use ratatui::widgets::{Block, Borders};
+
     let bar_block = Block::default()
         .borders(Borders::TOP)
         .border_set(border::ROUNDED)
@@ -221,10 +222,7 @@ pub fn render_footer(f: &mut Frame, app: &App, area: Rect) {
     // Split inner area: left for key hints, right for page indicator
     let bar_chunks = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Min(0),
-            Constraint::Length(20),
-        ])
+        .constraints([Constraint::Min(0), Constraint::Length(20)])
         .split(bar_inner);
 
     let p = Paragraph::new(Line::from(spans)).alignment(Alignment::Left);

--- a/src/ui/form.rs
+++ b/src/ui/form.rs
@@ -244,7 +244,7 @@ fn render_input<'a>(
         value.to_string()
     };
 
-    if is_active && is_editing && (tick / 15) % 2 == 0 {
+    if is_active && is_editing && (tick / 15).is_multiple_of(2) {
         if cursor_pos >= display_value.len() {
             display_value.push('█');
         } else {
@@ -280,6 +280,7 @@ fn render_input<'a>(
 }
 
 /// Helper to render a settings sub-screen with list + description + hints
+#[allow(clippy::too_many_arguments)]
 fn render_settings_subscreen(
     f: &mut Frame,
     area: Rect,
@@ -577,7 +578,7 @@ pub fn render_settings(f: &mut Frame, app: &mut App, area: Rect) {
             );
         }
         SettingsState::VideoModeSelection => {
-            let modes = vec![
+            let modes = [
                 (
                     "Enhanced",
                     "Interpolation, upscaling, soap opera effect for smoother video",
@@ -760,7 +761,7 @@ pub fn render_settings(f: &mut Frame, app: &mut App, area: Rect) {
             );
         }
         SettingsState::AutoRefreshSelection => {
-            let intervals = vec![
+            let intervals = [
                 ("Disabled", "Never auto-refresh playlist data on login"),
                 (
                     "Every 6 hours",
@@ -840,7 +841,7 @@ pub fn render_category_management(f: &mut Frame, app: &mut App, area: Rect) {
     };
 
     // Tabs for Content Type
-    let tabs = vec!["Live TV", "Movies", "Series"];
+    let tabs = ["Live TV", "Movies", "Series"];
     let tab_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([

--- a/src/ui/groups.rs
+++ b/src/ui/groups.rs
@@ -1,3 +1,7 @@
+use crate::app::App;
+use crate::ui::colors::{
+    HIGHLIGHT_BG, MATRIX_GREEN, SOFT_GREEN, TEXT_DIM, TEXT_PRIMARY, TEXT_SECONDARY,
+};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -5,8 +9,6 @@ use ratatui::{
     widgets::{Block, List, ListItem, Paragraph},
     Frame,
 };
-use crate::app::App;
-use crate::ui::colors::{MATRIX_GREEN, SOFT_GREEN, HIGHLIGHT_BG, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_DIM};
 
 /// Render the Group Management screen
 pub fn render_group_management(f: &mut Frame, app: &mut App, area: Rect) {
@@ -20,35 +22,76 @@ pub fn render_group_management(f: &mut Frame, app: &mut App, area: Rect) {
         .split(area);
 
     let title = Paragraph::new(Line::from(vec![
-        Span::styled("  groups", Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD)),
-        Span::styled(" · custom channel groups", Style::default().fg(TEXT_SECONDARY)),
+        Span::styled(
+            "  groups",
+            Style::default()
+                .fg(TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            " · custom channel groups",
+            Style::default().fg(TEXT_SECONDARY),
+        ),
     ]));
     f.render_widget(title, chunks[0]);
 
     let groups = &app.config.favorites.groups;
     let items: Vec<ListItem> = if groups.is_empty() {
         vec![ListItem::new(Line::from(vec![
-            Span::styled("  No groups yet. Press ", Style::default().fg(TEXT_SECONDARY)),
-            Span::styled("n", Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "  No groups yet. Press ",
+                Style::default().fg(TEXT_SECONDARY),
+            ),
+            Span::styled(
+                "n",
+                Style::default()
+                    .fg(MATRIX_GREEN)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" to create one.", Style::default().fg(TEXT_SECONDARY)),
         ]))]
     } else {
-        groups.iter().map(|g| {
-            let icon = g.icon.as_deref().unwrap_or("");
-            let count = g.stream_ids.len();
-            let prefix = if icon.is_empty() { "  ".to_string() } else { format!("  {} ", icon) };
-            ListItem::new(Line::from(vec![
-                Span::styled(prefix, Style::default().fg(SOFT_GREEN)),
-                Span::styled(&g.name, Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
-                Span::styled(format!("  {} channels", count), Style::default().fg(TEXT_DIM)),
-            ]))
-        }).collect()
+        groups
+            .iter()
+            .map(|g| {
+                let icon = g.icon.as_deref().unwrap_or("");
+                let count = g.stream_ids.len();
+                let prefix = if icon.is_empty() {
+                    "  ".to_string()
+                } else {
+                    format!("  {} ", icon)
+                };
+                ListItem::new(Line::from(vec![
+                    Span::styled(prefix, Style::default().fg(SOFT_GREEN)),
+                    Span::styled(
+                        &g.name,
+                        Style::default()
+                            .fg(MATRIX_GREEN)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        format!("  {} channels", count),
+                        Style::default().fg(TEXT_DIM),
+                    ),
+                ]))
+            })
+            .collect()
     };
 
-    let inner_area = crate::ui::common::render_matrix_box(f, chunks[1], &format!("groups ({})", groups.len()), SOFT_GREEN);
+    let inner_area = crate::ui::common::render_matrix_box(
+        f,
+        chunks[1],
+        &format!("groups ({})", groups.len()),
+        SOFT_GREEN,
+    );
 
     let list = List::new(items)
-        .highlight_style(Style::default().bg(HIGHLIGHT_BG).fg(MATRIX_GREEN).add_modifier(Modifier::BOLD))
+        .highlight_style(
+            Style::default()
+                .bg(HIGHLIGHT_BG)
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        )
         .highlight_symbol(" ▎");
 
     f.render_stateful_widget(list, inner_area, &mut app.group_list_state);
@@ -56,11 +99,16 @@ pub fn render_group_management(f: &mut Frame, app: &mut App, area: Rect) {
     let key_style = Style::default().fg(MATRIX_GREEN);
     let label_style = Style::default().fg(TEXT_SECONDARY);
     let help = Paragraph::new(Line::from(vec![
-        Span::styled("n", key_style), Span::styled(" new  ", label_style),
-        Span::styled("d", key_style), Span::styled(" delete  ", label_style),
-        Span::styled("enter", key_style), Span::styled(" view  ", label_style),
-        Span::styled("esc", key_style), Span::styled(" back", label_style),
-    ])).alignment(Alignment::Center);
+        Span::styled("n", key_style),
+        Span::styled(" new  ", label_style),
+        Span::styled("d", key_style),
+        Span::styled(" delete  ", label_style),
+        Span::styled("enter", key_style),
+        Span::styled(" view  ", label_style),
+        Span::styled("esc", key_style),
+        Span::styled(" back", label_style),
+    ]))
+    .alignment(Alignment::Center);
     f.render_widget(help, chunks[2]);
 }
 
@@ -70,7 +118,7 @@ pub fn render_group_picker(f: &mut Frame, app: &mut App, area: Rect) {
     let popup_height = (app.config.favorites.groups.len() as u16 + 5)
         .min(15)
         .min(area.height.saturating_sub(2));
-    
+
     let popup_x = area.x + (area.width.saturating_sub(popup_width)) / 2;
     let popup_y = area.y + (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(popup_x, popup_y, popup_width, popup_height);
@@ -87,30 +135,49 @@ pub fn render_group_picker(f: &mut Frame, app: &mut App, area: Rect) {
         ])
         .split(popup_area);
 
-    let title = Paragraph::new(Line::from(vec![
-        Span::styled("add to group", Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
-    ]))
-    .alignment(Alignment::Center)
-    ;
+    let title = Paragraph::new(Line::from(vec![Span::styled(
+        "add to group",
+        Style::default()
+            .fg(MATRIX_GREEN)
+            .add_modifier(Modifier::BOLD),
+    )]))
+    .alignment(Alignment::Center);
     f.render_widget(title, chunks[0]);
 
     let groups = &app.config.favorites.groups;
-    let mut items: Vec<ListItem> = groups.iter().map(|g| {
-        let icon = g.icon.as_deref().unwrap_or("");
-        let prefix = if icon.is_empty() { "  ".to_string() } else { format!(" {} ", icon) };
-        ListItem::new(Line::from(vec![
-            Span::styled(prefix, Style::default().fg(SOFT_GREEN)),
-            Span::styled(&g.name, Style::default().fg(MATRIX_GREEN)),
-        ]))
-    }).collect();
+    let mut items: Vec<ListItem> = groups
+        .iter()
+        .map(|g| {
+            let icon = g.icon.as_deref().unwrap_or("");
+            let prefix = if icon.is_empty() {
+                "  ".to_string()
+            } else {
+                format!(" {} ", icon)
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(prefix, Style::default().fg(SOFT_GREEN)),
+                Span::styled(&g.name, Style::default().fg(MATRIX_GREEN)),
+            ]))
+        })
+        .collect();
 
     items.push(ListItem::new(Line::from(vec![
-        Span::styled(" + ", Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            " + ",
+            Style::default()
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled("Create New Group...", Style::default().fg(TEXT_PRIMARY)),
     ])));
 
     let list = List::new(items)
-        .highlight_style(Style::default().bg(HIGHLIGHT_BG).fg(MATRIX_GREEN).add_modifier(Modifier::BOLD))
+        .highlight_style(
+            Style::default()
+                .bg(HIGHLIGHT_BG)
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        )
         .highlight_symbol(" ▎");
 
     f.render_stateful_widget(list, chunks[1], &mut app.group_list_state);
@@ -120,6 +187,7 @@ pub fn render_group_picker(f: &mut Frame, app: &mut App, area: Rect) {
         Span::styled(" add · ", Style::default().fg(TEXT_SECONDARY)),
         Span::styled("esc", Style::default().fg(MATRIX_GREEN)),
         Span::styled(" cancel", Style::default().fg(TEXT_SECONDARY)),
-    ])).alignment(Alignment::Center);
+    ]))
+    .alignment(Alignment::Center);
     f.render_widget(help, chunks[2]);
 }

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -1,3 +1,7 @@
+use crate::app::{App, CurrentScreen};
+use crate::ui::colors::{MATRIX_GREEN, TEXT_DIM, TEXT_PRIMARY, TEXT_SECONDARY};
+use chrono::{TimeZone, Utc};
+use chrono_tz::Tz;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -5,45 +9,46 @@ use ratatui::{
     widgets::Paragraph,
     Frame,
 };
-use chrono::{Utc, TimeZone};
-use chrono_tz::Tz;
 use std::str::FromStr;
-use crate::app::{App, CurrentScreen};
-use crate::ui::colors::{MATRIX_GREEN, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_DIM};
 
 fn clean_val(v: &crate::flex_id::FlexId) -> String {
     v.to_string_value().unwrap_or_default()
 }
 
 pub fn render_header(f: &mut Frame, app: &App, area: Rect) {
-    use ratatui::widgets::{Block, Borders};
     use ratatui::symbols::border;
+    use ratatui::widgets::{Block, Borders};
 
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Min(0),
-            Constraint::Length(60),
-        ])
+        .constraints([Constraint::Min(0), Constraint::Length(60)])
         .split(area);
 
     // Common border style
     let border_style = Style::default().fg(MATRIX_GREEN);
-    
+
     // 1. Search Mode (Prominent Input Box)
     if app.search_mode {
         let search_block = Block::default()
             .borders(Borders::ALL)
             .border_set(border::ROUNDED)
             .border_style(border_style)
-            .title(Span::styled(" Search Query ", Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)));
-        
+            .title(Span::styled(
+                " Search Query ",
+                Style::default()
+                    .fg(MATRIX_GREEN)
+                    .add_modifier(Modifier::BOLD),
+            ));
+
         let inner = search_block.inner(area);
         f.render_widget(search_block, area);
 
         let search_text = format!(" >_ {}", app.search_state.query);
-        let p = Paragraph::new(search_text)
-            .style(Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD));
+        let p = Paragraph::new(search_text).style(
+            Style::default()
+                .fg(TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        );
         f.render_widget(p, inner);
         return;
     }
@@ -68,81 +73,139 @@ pub fn render_header(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(right_block, chunks[1]);
 
     let mut left_spans: Vec<Span> = Vec::new();
-    
+
     // Breadcrumb Content setup
     let mut add_breadcrumb = |text: &str, is_active: bool| {
         if !left_spans.is_empty() {
             left_spans.push(Span::styled(" › ", Style::default().fg(TEXT_DIM)));
         }
         if is_active {
-            left_spans.push(Span::styled(text.to_string(), Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)));
+            left_spans.push(Span::styled(
+                text.to_string(),
+                Style::default()
+                    .fg(MATRIX_GREEN)
+                    .add_modifier(Modifier::BOLD),
+            ));
         } else {
-            left_spans.push(Span::styled(text.to_string(), Style::default().fg(TEXT_SECONDARY)));
+            left_spans.push(Span::styled(
+                text.to_string(),
+                Style::default().fg(TEXT_SECONDARY),
+            ));
         }
     };
 
     match app.current_screen {
         CurrentScreen::Home => add_breadcrumb("home", true),
-        CurrentScreen::Categories => { add_breadcrumb("home", false); add_breadcrumb("tv", true); },
+        CurrentScreen::Categories => {
+            add_breadcrumb("home", false);
+            add_breadcrumb("tv", true);
+        }
         CurrentScreen::Streams => {
-            add_breadcrumb("home", false); add_breadcrumb("tv", false); add_breadcrumb("streams", false);
+            add_breadcrumb("home", false);
+            add_breadcrumb("tv", false);
+            add_breadcrumb("streams", false);
             if let Some(cat) = app.categories.get(app.selected_category_index) {
                 add_breadcrumb(&cat.category_name, true);
             }
-        },
-        CurrentScreen::VodCategories => { add_breadcrumb("home", false); add_breadcrumb("movies", true); },
+        }
+        CurrentScreen::VodCategories => {
+            add_breadcrumb("home", false);
+            add_breadcrumb("movies", true);
+        }
         CurrentScreen::VodStreams => {
-            add_breadcrumb("home", false); add_breadcrumb("movies", false); add_breadcrumb("browse", false);
+            add_breadcrumb("home", false);
+            add_breadcrumb("movies", false);
+            add_breadcrumb("browse", false);
             if let Some(cat) = app.vod_categories.get(app.selected_vod_category_index) {
                 add_breadcrumb(&cat.category_name, true);
             }
-        },
-        CurrentScreen::SeriesCategories => { add_breadcrumb("home", false); add_breadcrumb("series", true); },
+        }
+        CurrentScreen::SeriesCategories => {
+            add_breadcrumb("home", false);
+            add_breadcrumb("series", true);
+        }
         CurrentScreen::SeriesStreams => {
-            add_breadcrumb("home", false); add_breadcrumb("series", false); add_breadcrumb("browse", false);
-            if let Some(cat) = app.series_categories.get(app.selected_series_category_index) {
+            add_breadcrumb("home", false);
+            add_breadcrumb("series", false);
+            add_breadcrumb("browse", false);
+            if let Some(cat) = app
+                .series_categories
+                .get(app.selected_series_category_index)
+            {
                 add_breadcrumb(&cat.category_name, true);
             }
-        },
-        CurrentScreen::Settings => { add_breadcrumb("home", false); add_breadcrumb("settings", true); },
-        CurrentScreen::SportsDashboard => { add_breadcrumb("home", false); add_breadcrumb("sports", true); },
-        CurrentScreen::GlobalSearch => { add_breadcrumb("home", false); add_breadcrumb("search", true); },
+        }
+        CurrentScreen::Settings => {
+            add_breadcrumb("home", false);
+            add_breadcrumb("settings", true);
+        }
+        CurrentScreen::SportsDashboard => {
+            add_breadcrumb("home", false);
+            add_breadcrumb("sports", true);
+        }
+        CurrentScreen::GlobalSearch => {
+            add_breadcrumb("home", false);
+            add_breadcrumb("search", true);
+        }
         _ => add_breadcrumb("matrix-iptv", true),
     }
 
     // Background refresh
     if app.background_refresh_active {
-        left_spans.push(Span::styled("  ⟳ syncing...", Style::default().fg(Color::Rgb(80, 160, 80))));
+        left_spans.push(Span::styled(
+            "  ⟳ syncing...",
+            Style::default().fg(Color::Rgb(80, 160, 80)),
+        ));
     }
 
     let tabs = Paragraph::new(Line::from(left_spans));
     f.render_widget(tabs, left_inner);
 
     // System/Account Info Context
-    if let Some(_) = &app.current_client {
-        let name = app.config.accounts.get(app.selected_account_index).map(|a| a.name.clone()).unwrap_or_else(|| "Unknown".to_string());
+    if app.current_client.is_some() {
+        let name = app
+            .config
+            .accounts
+            .get(app.selected_account_index)
+            .map(|a| a.name.clone())
+            .unwrap_or_else(|| "Unknown".to_string());
         let tz_str = app.config.get_user_timezone();
         let user_tz: Tz = Tz::from_str(&tz_str).unwrap_or(chrono_tz::Europe::London);
         let now = Utc::now().with_timezone(&user_tz);
         let time = now.format("%I:%M %p").to_string();
 
         let (_active, _total, exp) = if let Some(info) = &app.account_info {
-            let a = info.active_cons.as_ref().map(clean_val).unwrap_or_else(|| "0".to_string());
-            let t = info.max_connections.as_ref().map(clean_val).unwrap_or_else(|| "1".to_string());
-            let e = info.exp_date.as_ref().map(clean_val).unwrap_or_else(|| "N/A".to_string());
+            let a = info
+                .active_cons
+                .as_ref()
+                .map(clean_val)
+                .unwrap_or_else(|| "0".to_string());
+            let t = info
+                .max_connections
+                .as_ref()
+                .map(clean_val)
+                .unwrap_or_else(|| "1".to_string());
+            let e = info
+                .exp_date
+                .as_ref()
+                .map(clean_val)
+                .unwrap_or_else(|| "N/A".to_string());
             (a, t, e)
         } else {
             ("?".to_string(), "?".to_string(), "N/A".to_string())
         };
 
         let exp_formatted = if let Ok(ts) = exp.parse::<i64>() {
-             Utc.timestamp_opt(ts, 0).single().map(|dt| dt.format("%Y-%m-%d").to_string()).unwrap_or(exp)
+            Utc.timestamp_opt(ts, 0)
+                .single()
+                .map(|dt| dt.format("%Y-%m-%d").to_string())
+                .unwrap_or(exp)
         } else {
             exp
         };
 
         let mut right_spans = Vec::new();
-        
+
         // Mode keys (Filter-like look) - Moved to right side
         if !app.config.processing_modes.is_empty() {
             let mut first = true;
@@ -154,13 +217,31 @@ pub fn render_header(f: &mut Frame, app: &App, area: Rect) {
 
                 match mode {
                     crate::config::ProcessingMode::Merica => {
-                        right_spans.push(Span::styled("'MERICA", Style::default().fg(Color::Rgb(0, 0, 0)).bg(Color::Rgb(255, 200, 80)).add_modifier(Modifier::BOLD)));
+                        right_spans.push(Span::styled(
+                            "'MERICA",
+                            Style::default()
+                                .fg(Color::Rgb(0, 0, 0))
+                                .bg(Color::Rgb(255, 200, 80))
+                                .add_modifier(Modifier::BOLD),
+                        ));
                     }
                     crate::config::ProcessingMode::Sports => {
-                        right_spans.push(Span::styled("SPORTS", Style::default().fg(Color::Rgb(0, 0, 0)).bg(MATRIX_GREEN).add_modifier(Modifier::BOLD)));
+                        right_spans.push(Span::styled(
+                            "SPORTS",
+                            Style::default()
+                                .fg(Color::Rgb(0, 0, 0))
+                                .bg(MATRIX_GREEN)
+                                .add_modifier(Modifier::BOLD),
+                        ));
                     }
                     crate::config::ProcessingMode::AllEnglish => {
-                        right_spans.push(Span::styled("EN", Style::default().fg(Color::Rgb(0, 0, 0)).bg(TEXT_PRIMARY).add_modifier(Modifier::BOLD)));
+                        right_spans.push(Span::styled(
+                            "EN",
+                            Style::default()
+                                .fg(Color::Rgb(0, 0, 0))
+                                .bg(TEXT_PRIMARY)
+                                .add_modifier(Modifier::BOLD),
+                        ));
                     }
                 }
             }
@@ -168,18 +249,31 @@ pub fn render_header(f: &mut Frame, app: &App, area: Rect) {
         }
 
         // Account Badge
-        right_spans.push(Span::styled(format!(" {} ", name), Style::default().fg(Color::Rgb(0, 0, 0)).bg(MATRIX_GREEN).add_modifier(Modifier::BOLD)));
+        right_spans.push(Span::styled(
+            format!(" {} ", name),
+            Style::default()
+                .fg(Color::Rgb(0, 0, 0))
+                .bg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ));
         right_spans.push(Span::styled(" ", Style::default()));
-        
-        // Time
-        right_spans.push(Span::styled(&time, Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD)));
-        right_spans.push(Span::styled(" ", Style::default()));
-        
-        // Exp Date
-        right_spans.push(Span::styled(format!("Exp: {}", exp_formatted), Style::default().fg(TEXT_SECONDARY)));
 
-        let stats = Paragraph::new(Line::from(right_spans))
-            .alignment(Alignment::Right);
+        // Time
+        right_spans.push(Span::styled(
+            &time,
+            Style::default()
+                .fg(TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        ));
+        right_spans.push(Span::styled(" ", Style::default()));
+
+        // Exp Date
+        right_spans.push(Span::styled(
+            format!("Exp: {}", exp_formatted),
+            Style::default().fg(TEXT_SECONDARY),
+        ));
+
+        let stats = Paragraph::new(Line::from(right_spans)).alignment(Alignment::Right);
         f.render_widget(stats, right_inner);
     }
 }

--- a/src/ui/loading.rs
+++ b/src/ui/loading.rs
@@ -1,3 +1,5 @@
+use crate::app::App;
+use crate::ui::colors::{MATRIX_GREEN, SOFT_GREEN, TEXT_DIM, TEXT_PRIMARY, TEXT_SECONDARY};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -5,8 +7,6 @@ use ratatui::{
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
-use crate::app::App;
-use crate::ui::colors::{MATRIX_GREEN, SOFT_GREEN, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_DIM};
 
 pub fn render_loading(f: &mut Frame, app: &App, area: Rect) {
     if !app.state_loading {
@@ -16,8 +16,8 @@ pub fn render_loading(f: &mut Frame, app: &App, area: Rect) {
     // Subtle overlay across the background
     let row = "░".repeat(area.width as usize);
     let lines = vec![Line::from(row.as_str()); area.height as usize];
-    let dim_paragraph = Paragraph::new(lines)
-        .style(Style::default().fg(Color::DarkGray).bg(Color::Rgb(0, 0, 0)));
+    let dim_paragraph =
+        Paragraph::new(lines).style(Style::default().fg(Color::DarkGray).bg(Color::Rgb(0, 0, 0)));
     f.render_widget(dim_paragraph, area);
 
     // Perfectly fitted fixed-height modal popup
@@ -26,7 +26,11 @@ pub fn render_loading(f: &mut Frame, app: &App, area: Rect) {
 
     // Dynamic title: show % when progress is available
     let title = if let Some(ref progress) = app.loading_progress {
-        let pct = if progress.total > 0 { (progress.current * 100) / progress.total } else { 0 };
+        let pct = if progress.total > 0 {
+            (progress.current * 100) / progress.total
+        } else {
+            0
+        };
         format!(" loading  {}% ", pct)
     } else {
         " loading ".to_string()
@@ -37,7 +41,12 @@ pub fn render_loading(f: &mut Frame, app: &App, area: Rect) {
         .borders(Borders::ALL)
         .border_set(border::ROUNDED)
         .border_style(Style::default().fg(MATRIX_GREEN))
-        .title(Span::styled(title, Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)))
+        .title(Span::styled(
+            title,
+            Style::default()
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ))
         .title_alignment(Alignment::Center)
         .style(Style::default().bg(Color::Rgb(0, 0, 0)));
 
@@ -58,7 +67,12 @@ pub fn render_loading(f: &mut Frame, app: &App, area: Rect) {
     let tick = app.loading_tick;
 
     // Matrix style Katakana spinner and decoding effect
-    let katakana = ['ｦ', 'ｧ', 'ｨ', 'ｩ', 'ｪ', 'ｫ', 'ｬ', 'ｭ', 'ｮ', 'ｯ', 'ｰ', 'ｱ', 'ｲ', 'ｳ', 'ｴ', 'ｵ', 'ｶ', 'ｷ', 'ｸ', 'ｹ', 'ｺ', 'ｻ', 'ｼ', 'ｽ', 'ｾ', 'ｿ', 'ﾀ', 'ﾁ', 'ﾂ', 'ﾃ', 'ﾄ', 'ﾅ', 'ﾆ', 'ﾇ', 'ﾈ', 'ﾉ', 'ﾊ', 'ﾋ', 'ﾌ', 'ﾍ', 'ﾎ', 'ﾏ', 'ﾐ', 'ﾑ', 'ﾒ', 'ﾓ', 'ﾔ', 'ﾕ', 'ﾖ', 'ﾗ', 'ﾘ', 'ﾙ', 'ﾚ', 'ﾛ', 'ﾜ', 'ﾝ'];
+    let katakana = [
+        'ｦ', 'ｧ', 'ｨ', 'ｩ', 'ｪ', 'ｫ', 'ｬ', 'ｭ', 'ｮ', 'ｯ', 'ｰ', 'ｱ', 'ｲ', 'ｳ', 'ｴ', 'ｵ', 'ｶ', 'ｷ',
+        'ｸ', 'ｹ', 'ｺ', 'ｻ', 'ｼ', 'ｽ', 'ｾ', 'ｿ', 'ﾀ', 'ﾁ', 'ﾂ', 'ﾃ', 'ﾄ', 'ﾅ', 'ﾆ', 'ﾇ', 'ﾈ', 'ﾉ',
+        'ﾊ', 'ﾋ', 'ﾌ', 'ﾍ', 'ﾎ', 'ﾏ', 'ﾐ', 'ﾑ', 'ﾒ', 'ﾓ', 'ﾔ', 'ﾕ', 'ﾖ', 'ﾗ', 'ﾘ', 'ﾙ', 'ﾚ', 'ﾛ',
+        'ﾜ', 'ﾝ',
+    ];
     let spinner = katakana[(tick as usize) % katakana.len()];
 
     let glitch_len = 8;
@@ -68,34 +82,67 @@ pub fn render_loading(f: &mut Frame, app: &App, area: Rect) {
         glitch_str.push(katakana[char_idx]);
     }
 
-    let current_msg = app.loading_message.as_deref().unwrap_or("Initializing system...");
+    let current_msg = app
+        .loading_message
+        .as_deref()
+        .unwrap_or("Initializing system...");
 
     // ── Hero line ─────────────────────────────────────────────
     // Matrix style: Katakana spinner + Message + Glitch decoding tail
     let hero = Paragraph::new(Line::from(vec![
-        Span::styled(format!("{} ", spinner), Style::default().fg(Color::Rgb(200, 255, 200)).add_modifier(Modifier::BOLD)),
-        Span::styled(current_msg, Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD)),
-        Span::styled(format!(" [{}]", glitch_str), Style::default().fg(MATRIX_GREEN)),
+        Span::styled(
+            format!("{} ", spinner),
+            Style::default()
+                .fg(Color::Rgb(200, 255, 200))
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            current_msg,
+            Style::default()
+                .fg(TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!(" [{}]", glitch_str),
+            Style::default().fg(MATRIX_GREEN),
+        ),
     ]));
     f.render_widget(hero, chunks[0]);
 
     // ── Progress bar ──────────────────────────────────────────
     if let Some(ref progress) = app.loading_progress {
-        let pct = if progress.total > 0 { (progress.current * 100) / progress.total } else { 0 };
+        let pct = if progress.total > 0 {
+            (progress.current * 100) / progress.total
+        } else {
+            0
+        };
         // Dynamic bar width: pad to fit inside border margins
-        let bar_width = (popup_area.width as usize).saturating_sub(22).max(10).min(40);
+        let bar_width = (popup_area.width as usize).saturating_sub(22).clamp(10, 40);
         let filled = (pct * bar_width) / 100;
         let empty = bar_width.saturating_sub(filled);
         let bar = format!("{}{}", "█".repeat(filled), "░".repeat(empty));
 
-        let eta_str = progress.eta.as_ref().map(|d| {
-            let secs = d.as_secs();
-            if secs >= 60 { format!("{}m {}s", secs / 60, secs % 60) } else { format!("{}s", secs) }
-        }).unwrap_or_else(|| "…".to_string());
+        let eta_str = progress
+            .eta
+            .as_ref()
+            .map(|d| {
+                let secs = d.as_secs();
+                if secs >= 60 {
+                    format!("{}m {}s", secs / 60, secs % 60)
+                } else {
+                    format!("{}s", secs)
+                }
+            })
+            .unwrap_or_else(|| "…".to_string());
 
         let bar_line = Paragraph::new(Line::from(vec![
             Span::styled(format!("[{}]", bar), Style::default().fg(SOFT_GREEN)),
-            Span::styled(format!("  {:>3}%", pct), Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                format!("  {:>3}%", pct),
+                Style::default()
+                    .fg(TEXT_PRIMARY)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled(
                 format!("  {}/{}", progress.current, progress.total),
                 Style::default().fg(TEXT_SECONDARY),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,17 +1,17 @@
 pub mod colors;
-pub mod utils;
 pub mod common;
-pub mod header;
 pub mod footer;
+pub mod form;
+pub mod groups;
+pub mod header;
+pub mod home;
+pub mod loading;
 pub mod panes;
 pub mod popups;
-pub mod loading;
-pub mod form;
-pub mod home;
-pub mod vod;
 pub mod series;
-pub mod groups;
 pub mod sports;
+pub mod utils;
+pub mod vod;
 
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
@@ -32,9 +32,8 @@ pub fn ui(f: &mut Frame, app: &mut App) {
     // Prevent terminal background bleed (gray artifacting)
     f.render_widget(ratatui::widgets::Clear, area);
     f.render_widget(
-        ratatui::widgets::Block::default()
-            .bg(ratatui::style::Color::Rgb(0, 0, 0)),
-        area
+        ratatui::widgets::Block::default().bg(ratatui::style::Color::Rgb(0, 0, 0)),
+        area,
     );
 
     // Base Screens
@@ -85,12 +84,11 @@ pub fn ui(f: &mut Frame, app: &mut App) {
         loading::render_loading(f, app, area);
     }
 
-
     // Matrix Rain Overlay (Draws on top of everything except Help/Guide/Error if they need focus, but effectively screensaver covers all)
     // Actually screensaver should be on top of everything.
     if app.show_matrix_rain {
-         #[cfg(not(target_arch = "wasm32"))]
-         crate::matrix_rain::render_matrix_rain(f, app, area);
+        #[cfg(not(target_arch = "wasm32"))]
+        crate::matrix_rain::render_matrix_rain(f, app, area);
     }
 
     // --- Screen Transition Effect ---
@@ -98,18 +96,23 @@ pub fn ui(f: &mut Frame, app: &mut App) {
     {
         // Compute per-frame delta time (clamped to 100ms max to avoid huge jumps)
         let now = std::time::Instant::now();
-        let delta = now.duration_since(app.frame_instant).min(std::time::Duration::from_millis(100));
+        let delta = now
+            .duration_since(app.frame_instant)
+            .min(std::time::Duration::from_millis(100));
         app.frame_instant = now;
         let last_tick = FxDuration::from_millis(delta.as_millis() as u32);
 
         // Detect screen change → spawn a new sweep-in effect
-        let screen_changed = app.transition_last_screen.as_ref().map_or(true, |s| *s != app.current_screen);
+        let screen_changed = app
+            .transition_last_screen
+            .as_ref()
+            .is_none_or(|s| *s != app.current_screen);
         if screen_changed && !app.show_matrix_rain {
             app.transition_last_screen = Some(app.current_screen.clone());
             let effect = fx::sweep_in(
                 tachyonfx::Motion::LeftToRight,
-                10,   // sweep width in cells
-                0,    // offset
+                10, // sweep width in cells
+                0,  // offset
                 ratatui::style::Color::Black,
                 tachyonfx::EffectTimer::from((
                     FxDuration::from_millis(350),
@@ -159,8 +162,8 @@ fn render_main_layout(f: &mut Frame, app: &mut App, area: Rect) {
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(header_height), // Header
-            Constraint::Min(0),     // Content
-            Constraint::Length(2), // Footer (bordered bottom bar)
+            Constraint::Min(0),                // Content
+            Constraint::Length(2),             // Footer (bordered bottom bar)
         ])
         .split(area);
 
@@ -177,11 +180,11 @@ fn render_main_layout(f: &mut Frame, app: &mut App, area: Rect) {
             } else {
                 // Show detail panel only if terminal is wide enough (>= 80 cols)
                 let show_detail = content_area.width >= 80;
-                
+
                 if show_detail {
-                    let detail_width = 30u16.min(content_area.width / 3); 
+                    let detail_width = 30u16.min(content_area.width / 3);
                     let streams_width = content_area.width.saturating_sub(detail_width);
-                    
+
                     let h_chunks = Layout::default()
                         .direction(Direction::Horizontal)
                         .constraints([
@@ -191,7 +194,9 @@ fn render_main_layout(f: &mut Frame, app: &mut App, area: Rect) {
                         .split(content_area);
 
                     // Check if current CATEGORY is sports (not per-stream — avoids jarring pop in/out)
-                    let is_sports_category = app.categories.get(app.selected_category_index)
+                    let is_sports_category = app
+                        .categories
+                        .get(app.selected_category_index)
                         .map(|c| crate::parser::is_sports_content(&c.category_name))
                         .unwrap_or(false);
 
@@ -199,10 +204,7 @@ fn render_main_layout(f: &mut Frame, app: &mut App, area: Rect) {
                         // Sports category: always show match intelligence at fixed compact height
                         let mid_chunks = Layout::default()
                             .direction(Direction::Vertical)
-                            .constraints([
-                                Constraint::Min(10),
-                                Constraint::Length(7),
-                            ])
+                            .constraints([Constraint::Min(10), Constraint::Length(7)])
                             .split(h_chunks[0]);
                         panes::render_streams_pane(f, app, mid_chunks[0], SOFT_GREEN);
                         panes::render_stream_details_pane(f, app, mid_chunks[1], SOFT_GREEN);
@@ -216,22 +218,19 @@ fn render_main_layout(f: &mut Frame, app: &mut App, area: Rect) {
                     // Narrow terminal: 1-column layout (streams only)
                     let h_chunks = Layout::default()
                         .direction(Direction::Horizontal)
-                        .constraints([
-                            Constraint::Percentage(100),
-                        ])
+                        .constraints([Constraint::Percentage(100)])
                         .split(content_area);
 
-                    let is_sports_category = app.categories.get(app.selected_category_index)
+                    let is_sports_category = app
+                        .categories
+                        .get(app.selected_category_index)
                         .map(|c| crate::parser::is_sports_content(&c.category_name))
                         .unwrap_or(false);
 
                     if is_sports_category {
                         let right_chunks = Layout::default()
                             .direction(Direction::Vertical)
-                            .constraints([
-                                Constraint::Min(10),
-                                Constraint::Length(7),
-                            ])
+                            .constraints([Constraint::Min(10), Constraint::Length(7)])
                             .split(h_chunks[0]);
                         panes::render_streams_pane(f, app, right_chunks[0], SOFT_GREEN);
                         panes::render_stream_details_pane(f, app, right_chunks[1], SOFT_GREEN);
@@ -255,10 +254,14 @@ fn render_main_layout(f: &mut Frame, app: &mut App, area: Rect) {
         }
         CurrentScreen::GlobalSearch => {
             // Check if focused result is a sports event OR has ESPN score data
-            let is_sports_event = app.global_search_results.get(app.selected_stream_index)
+            let is_sports_event = app
+                .global_search_results
+                .get(app.selected_stream_index)
                 .map(|s| {
-                    let parsed = crate::parser::parse_stream(&s.name, app.provider_timezone.as_deref());
-                    parsed.sports_event.is_some() || app.get_score_for_stream(&parsed.display_name).is_some()
+                    let parsed =
+                        crate::parser::parse_stream(&s.name, app.provider_timezone.as_deref());
+                    parsed.sports_event.is_some()
+                        || app.get_score_for_stream(&parsed.display_name).is_some()
                 })
                 .unwrap_or(false);
 
@@ -266,10 +269,7 @@ fn render_main_layout(f: &mut Frame, app: &mut App, area: Rect) {
                 let intel_height = 10u16;
                 let layout_chunks = Layout::default()
                     .direction(Direction::Vertical)
-                    .constraints([
-                        Constraint::Min(10),
-                        Constraint::Length(intel_height),
-                    ])
+                    .constraints([Constraint::Min(10), Constraint::Length(intel_height)])
                     .split(content_area);
 
                 panes::render_global_search_pane(f, app, layout_chunks[0]);

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -283,7 +283,7 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
         .enumerate()
         .skip(adjusted_start)
         .take(end - adjusted_start)
-        .map(|(idx, s)| {
+        .map(|(_idx, s)| {
             let _s_id = crate::api::get_id_str(&s.stream_id);
             let display_name = &s.name;
             

--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -1,23 +1,25 @@
-use std::sync::Arc;
+use crate::api::Category;
+use crate::app::{App, CurrentScreen};
+use crate::parser::{country_color, country_flag, parse_category, parse_stream};
+use crate::ui::colors::{
+    HIGHLIGHT_BG, MATRIX_GREEN, SOFT_GREEN, TEXT_DIM, TEXT_PRIMARY, TEXT_SECONDARY,
+};
+use crate::ui::common::stylize_channel_name;
+use chrono::{DateTime, Utc};
+use chrono_tz::Tz;
 use ratatui::{
-    layout::{Rect, Layout, Constraint, Direction},
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{List, ListItem, Paragraph, Block, Borders, Cell, Row, Table},
+    widgets::{Block, Borders, Cell, List, ListItem, Paragraph, Row, Table},
     Frame,
 };
-use crate::app::{App, CurrentScreen};
-use crate::api::Category;
-use crate::parser::{parse_category, parse_stream, country_flag, country_color};
-use crate::ui::colors::{MATRIX_GREEN, SOFT_GREEN, HIGHLIGHT_BG, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_DIM};
-use crate::ui::common::stylize_channel_name;
-use chrono::{Utc, DateTime};
-use chrono_tz::Tz;
+use std::sync::Arc;
 
 fn format_relative_time(dt: DateTime<Utc>, user_tz: &Tz) -> String {
     let local = dt.with_timezone(user_tz);
     let now = Utc::now().with_timezone(user_tz);
-    
+
     let day = if local.date_naive() == now.date_naive() {
         "Today".to_string()
     } else if (local.date_naive() - now.date_naive()).num_days() == 1 {
@@ -25,7 +27,7 @@ fn format_relative_time(dt: DateTime<Utc>, user_tz: &Tz) -> String {
     } else {
         local.format("%A").to_string()
     };
-    
+
     format!("{} {}", day, local.format("%I:%M %p"))
 }
 
@@ -47,15 +49,21 @@ pub fn render_categories_pane(f: &mut Frame, app: &mut App, area: Rect, border_c
 
 fn get_category_data(app: &App) -> (&Vec<Arc<Category>>, usize, &ratatui::widgets::TableState) {
     match app.current_screen {
-        CurrentScreen::VodCategories | CurrentScreen::VodStreams => {
-            (&app.vod_categories, app.selected_vod_category_index, &app.vod_category_list_state)
-        }
-        CurrentScreen::SeriesCategories | CurrentScreen::SeriesStreams => {
-            (&app.series_categories, app.selected_series_category_index, &app.series_category_list_state)
-        }
-        _ => {
-            (&app.categories, app.selected_category_index, &app.category_list_state)
-        }
+        CurrentScreen::VodCategories | CurrentScreen::VodStreams => (
+            &app.vod_categories,
+            app.selected_vod_category_index,
+            &app.vod_category_list_state,
+        ),
+        CurrentScreen::SeriesCategories | CurrentScreen::SeriesStreams => (
+            &app.series_categories,
+            app.selected_series_category_index,
+            &app.series_category_list_state,
+        ),
+        _ => (
+            &app.categories,
+            app.selected_category_index,
+            &app.category_list_state,
+        ),
     }
 }
 
@@ -63,25 +71,26 @@ fn render_categories_grid(f: &mut Frame, app: &mut App, area: Rect, border_color
     let row_height: u16 = 3;
     let title = " categories ";
     let is_active = app.active_pane == crate::app::Pane::Categories;
-    let inner_area = crate::ui::common::render_matrix_box_active(f, area, &title, border_color, is_active);
-    
+    let inner_area =
+        crate::ui::common::render_matrix_box_active(f, area, title, border_color, is_active);
+
     let max_name_len = app.max_category_name_len;
     let min_cell_width = (max_name_len as u16 + 10).max(14);
-    let cols = ((inner_area.width / min_cell_width) as usize).max(1).min(8);
+    let cols = ((inner_area.width / min_cell_width) as usize).clamp(1, 8);
     app.grid_cols = cols; // UPDATE BEFORE BORROWING categories_ref
-    
+
     let (categories_ref, selected, _) = get_category_data(app);
-    
+
     let max_rows = (inner_area.height / row_height).max(1) as usize;
     let items_per_page = max_rows * cols;
-    let total    = categories_ref.len();
+    let total = categories_ref.len();
 
-    let page      = selected / items_per_page.max(1);
+    let page = selected / items_per_page.max(1);
     let start_idx = page * items_per_page;
-    let end_idx   = (start_idx + items_per_page).min(total);
+    let end_idx = (start_idx + items_per_page).min(total);
     let page_items = end_idx - start_idx;
-    let num_rows  = ((page_items as f32) / (cols as f32)).ceil() as usize;
-    
+    let num_rows = ((page_items as f32) / (cols as f32)).ceil() as usize;
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints(vec![Constraint::Length(row_height); num_rows])
@@ -95,17 +104,19 @@ fn render_categories_grid(f: &mut Frame, app: &mut App, area: Rect, border_color
 
         for (j, cell_area) in cells.iter().enumerate() {
             let idx = start_idx + (i * cols) + j;
-            if idx >= end_idx { break; }
-            
-            let category  = &categories_ref[idx];
+            if idx >= end_idx {
+                break;
+            }
+
+            let category = &categories_ref[idx];
             let is_selected = idx == selected;
-            
+
             let block_style = if is_selected {
                 Style::default().fg(Color::Black).bg(MATRIX_GREEN)
             } else {
                 Style::default().fg(Color::White).bg(Color::Rgb(0, 0, 0))
             };
-            
+
             let parsed = if let Some(ref cached) = category.cached_parsed {
                 cached.as_ref().clone()
             } else {
@@ -117,8 +128,10 @@ fn render_categories_grid(f: &mut Frame, app: &mut App, area: Rect, border_color
                 .border_style(Style::default().fg(Color::White))
                 .style(block_style);
 
-            let mut name_style  = if is_selected {
-                Style::default().fg(Color::Black).add_modifier(Modifier::BOLD)
+            let mut name_style = if is_selected {
+                Style::default()
+                    .fg(Color::Black)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(Color::White)
             };
@@ -128,8 +141,7 @@ fn render_categories_grid(f: &mut Frame, app: &mut App, area: Rect, border_color
                 name_style = name_style.fg(Color::Cyan);
             }
 
-            let mut spans = vec![];
-            spans.push(Span::styled(parsed.display_name.as_str(), name_style));
+            let spans = vec![Span::styled(parsed.display_name.as_str(), name_style)];
 
             let content = Paragraph::new(vec![Line::from(spans)])
                 .block(card_block)
@@ -143,13 +155,14 @@ fn render_categories_grid(f: &mut Frame, app: &mut App, area: Rect, border_color
 fn render_categories_list(f: &mut Frame, app: &mut App, area: Rect, border_color: Color) {
     let title = " categories ";
     let is_active = app.active_pane == crate::app::Pane::Categories;
-    let inner_area = crate::ui::common::render_matrix_box_active(f, area, &title, border_color, is_active); 
+    let inner_area =
+        crate::ui::common::render_matrix_box_active(f, area, title, border_color, is_active);
 
     let max_name_len = app.max_category_name_len as u16;
-    let min_col_width = (max_name_len + 15).max(30); 
-    let cols = (inner_area.width / min_col_width).max(1).min(4) as usize;
+    let min_col_width = (max_name_len + 15).max(30);
+    let cols = (inner_area.width / min_col_width).clamp(1, 4) as usize;
     app.grid_cols = cols; // UPDATE BEFORE BORROWING categories_ref
-    
+
     let (categories_ref, selected, list_state_ref) = get_category_data(app);
     let total = categories_ref.len();
     if total == 0 {
@@ -164,17 +177,21 @@ fn render_categories_list(f: &mut Frame, app: &mut App, area: Rect, border_color
         }
     }
 
-    let rows = (total + cols - 1) / cols;
-    let full_cols = if total % cols == 0 { cols } else { total % cols };
-    
+    let rows = total.div_ceil(cols);
+    let full_cols = if total % cols == 0 {
+        cols
+    } else {
+        total % cols
+    };
+
     let mut list_items = Vec::new();
 
     for r in 0..rows {
         let mut cells = Vec::new();
-        
+
         for c in 0..cols {
             let col_size = if c < full_cols { rows } else { rows - 1 };
-            
+
             if r < col_size {
                 let mut base_idx = 0;
                 for i in 0..c {
@@ -184,21 +201,33 @@ fn render_categories_list(f: &mut Frame, app: &mut App, area: Rect, border_color
                 let cat = &categories_ref[abs_idx];
 
                 let is_selected = abs_idx == selected;
-                
+
                 let upper_cat = if let Some(ref parsed) = cat.cached_parsed {
                     parsed.display_name.to_uppercase()
                 } else {
-                    crate::parser::parse_category(&cat.category_name).display_name.to_uppercase()
+                    crate::parser::parse_category(&cat.category_name)
+                        .display_name
+                        .to_uppercase()
                 };
-                
-                let fav_marker = if app.config.favorites.categories.contains(&cat.category_id) { "*" } else { " " };
-                let pre_pad = if is_selected && is_active { "█ " } else { "  " };
+
+                let fav_marker = if app.config.favorites.categories.contains(&cat.category_id) {
+                    "*"
+                } else {
+                    " "
+                };
+                let pre_pad = if is_selected && is_active {
+                    "█ "
+                } else {
+                    "  "
+                };
                 let name_clean = format!("{}{}{}", pre_pad, fav_marker, upper_cat);
 
                 let mut style = if is_selected && is_active {
                     list_highlight_style()
                 } else if is_selected && !is_active {
-                    Style::default().fg(Color::DarkGray).add_modifier(Modifier::REVERSED)
+                    Style::default()
+                        .fg(Color::DarkGray)
+                        .add_modifier(Modifier::REVERSED)
                 } else if !is_active {
                     Style::default().fg(Color::DarkGray)
                 } else {
@@ -214,12 +243,12 @@ fn render_categories_list(f: &mut Frame, app: &mut App, area: Rect, border_color
             } else {
                 cells.push(Cell::from(""));
             }
-            
+
             if c < cols - 1 {
                 cells.push(Cell::from(""));
             }
         }
-        
+
         list_items.push(Row::new(cells));
     }
 
@@ -236,19 +265,19 @@ fn render_categories_list(f: &mut Frame, app: &mut App, area: Rect, border_color
 
     // We can't update app.category_list_state directly if it's not the right one.
     // We'll update the state based on screen.
-    let mut state = list_state_ref.clone();
+    let mut state = *list_state_ref;
     state.select(Some(r));
-    
+
     // Update the app's state for the specific screen
     match app.current_screen {
         CurrentScreen::VodCategories | CurrentScreen::VodStreams => {
-            app.vod_category_list_state = state.clone();
+            app.vod_category_list_state = state;
         }
         CurrentScreen::SeriesCategories | CurrentScreen::SeriesStreams => {
-            app.series_category_list_state = state.clone();
+            app.series_category_list_state = state;
         }
         _ => {
-            app.category_list_state = state.clone();
+            app.category_list_state = state;
         }
     }
 
@@ -261,11 +290,7 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
     let selected = app.selected_stream_index;
 
     let half_window = visible_height / 2;
-    let start = if selected > half_window {
-        selected - half_window
-    } else {
-        0
-    };
+    let start = selected.saturating_sub(half_window);
     let end = (start + visible_height + half_window).min(total);
     let adjusted_start = if end == total && end > visible_height + half_window {
         end.saturating_sub(visible_height + half_window)
@@ -275,7 +300,11 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
 
     let user_tz_str = app.config.get_user_timezone();
     let user_tz: Tz = user_tz_str.parse().unwrap_or(chrono_tz::UTC);
-    let tz_display = format!("{} ({})", user_tz_str, Utc::now().with_timezone(&user_tz).format("%Z"));
+    let tz_display = format!(
+        "{} ({})",
+        user_tz_str,
+        Utc::now().with_timezone(&user_tz).format("%Z")
+    );
 
     let items: Vec<ListItem> = app
         .streams
@@ -286,9 +315,9 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
         .map(|(_idx, s)| {
             let _s_id = crate::api::get_id_str(&s.stream_id);
             let display_name = &s.name;
-            
+
             let parsed = if let Some(ref cached) = s.cached_parsed {
-                 cached.as_ref().clone()
+                cached.as_ref().clone()
             } else {
                 crate::parser::parse_stream(display_name, app.provider_timezone.as_deref())
             };
@@ -302,61 +331,119 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
                 return ListItem::new(Line::from(vec![
                     ratatui::text::Span::styled("     ", Style::default()),
                     ratatui::text::Span::styled("│", Style::default().fg(TEXT_DIM)),
-                    ratatui::text::Span::styled(label, Style::default().fg(TEXT_DIM).add_modifier(Modifier::DIM)),
+                    ratatui::text::Span::styled(
+                        label,
+                        Style::default().fg(TEXT_DIM).add_modifier(Modifier::DIM),
+                    ),
                 ]));
             }
 
             let now = Utc::now();
             let is_ended = parsed.stop_time.map(|t| now > t).unwrap_or(false);
             let is_live = parsed.start_time.map(|st| now >= st).unwrap_or(false) && !is_ended;
-            let is_blink_on = app.loading_tick / 4 % 2 == 0;
+            let is_blink_on = (app.loading_tick / 4).is_multiple_of(2);
 
             let mut spans = vec![];
-            
+
             // 0. Channel number column (fixed width, right-aligned) — use unique stream_id
             let ch_num = crate::api::get_id_str(&s.stream_id);
             let row_num = format!("{:<6} ", ch_num);
-            spans.push(ratatui::text::Span::styled(row_num, Style::default().fg(TEXT_DIM)));
-            spans.push(ratatui::text::Span::styled(" ", Style::default().fg(TEXT_DIM)));
-            
+            spans.push(ratatui::text::Span::styled(
+                row_num,
+                Style::default().fg(TEXT_DIM),
+            ));
+            spans.push(ratatui::text::Span::styled(
+                " ",
+                Style::default().fg(TEXT_DIM),
+            ));
+
             // 1. Icon Logic (Sports Only)
             let mut league_icon_span: Option<ratatui::text::Span> = None;
             let upper_name = parsed.display_name.to_uppercase();
             if upper_name.contains("NBA") || upper_name.contains("NCAAB") {
-                league_icon_span = Some(ratatui::text::Span::styled("NBA ", Style::default().fg(Color::Rgb(255, 140, 0))));
+                league_icon_span = Some(ratatui::text::Span::styled(
+                    "NBA ",
+                    Style::default().fg(Color::Rgb(255, 140, 0)),
+                ));
             } else if upper_name.contains("NFL") || upper_name.contains("NCAAF") {
-                league_icon_span = Some(ratatui::text::Span::styled("NFL ", Style::default().fg(Color::Rgb(210, 180, 140))));
+                league_icon_span = Some(ratatui::text::Span::styled(
+                    "NFL ",
+                    Style::default().fg(Color::Rgb(210, 180, 140)),
+                ));
             } else if upper_name.contains("MLB") || upper_name.contains("MILB") {
                 league_icon_span = Some(ratatui::text::Span::raw("MLB "));
             } else if upper_name.contains("NHL") {
                 league_icon_span = Some(ratatui::text::Span::raw("NHL "));
-            } else if upper_name.contains("UFC") || upper_name.contains("FIGHT") || upper_name.contains("BOXING") {
+            } else if upper_name.contains("UFC")
+                || upper_name.contains("FIGHT")
+                || upper_name.contains("BOXING")
+            {
                 league_icon_span = Some(ratatui::text::Span::raw("COMBAT "));
-            } else if upper_name.contains("TENNIS") || upper_name.contains("ATP") || upper_name.contains("WTA") {
-                league_icon_span = Some(ratatui::text::Span::styled("TENNIS ", Style::default().fg(Color::Rgb(144, 238, 144))));
-            } else if upper_name.contains("GOLF") || upper_name.contains("PGA") || upper_name.contains("MASTERS") {
+            } else if upper_name.contains("TENNIS")
+                || upper_name.contains("ATP")
+                || upper_name.contains("WTA")
+            {
+                league_icon_span = Some(ratatui::text::Span::styled(
+                    "TENNIS ",
+                    Style::default().fg(Color::Rgb(144, 238, 144)),
+                ));
+            } else if upper_name.contains("GOLF")
+                || upper_name.contains("PGA")
+                || upper_name.contains("MASTERS")
+            {
                 league_icon_span = Some(ratatui::text::Span::raw("GOLF "));
-            } else if upper_name.contains("SUPERCROSS") || upper_name.contains("MOTOCROSS") || upper_name.contains("F1") || upper_name.contains("NASCAR") || upper_name.contains("RACING") {
-                league_icon_span = Some(ratatui::text::Span::styled("RACE ", Style::default().fg(Color::Rgb(255, 100, 100))));
-            } else if upper_name.contains("SOCCER") || upper_name.contains("MLS") || upper_name.contains("PREMIER") || upper_name.contains("LALIGA") || upper_name.contains("FIFA") || upper_name.contains("UEFA") {
-                league_icon_span = Some(ratatui::text::Span::styled("SOCCER ", Style::default().fg(Color::Rgb(255, 182, 193))));
+            } else if upper_name.contains("SUPERCROSS")
+                || upper_name.contains("MOTOCROSS")
+                || upper_name.contains("F1")
+                || upper_name.contains("NASCAR")
+                || upper_name.contains("RACING")
+            {
+                league_icon_span = Some(ratatui::text::Span::styled(
+                    "RACE ",
+                    Style::default().fg(Color::Rgb(255, 100, 100)),
+                ));
+            } else if upper_name.contains("SOCCER")
+                || upper_name.contains("MLS")
+                || upper_name.contains("PREMIER")
+                || upper_name.contains("LALIGA")
+                || upper_name.contains("FIFA")
+                || upper_name.contains("UEFA")
+            {
+                league_icon_span = Some(ratatui::text::Span::styled(
+                    "SOCCER ",
+                    Style::default().fg(Color::Rgb(255, 182, 193)),
+                ));
             } else if upper_name.contains("RUGBY") {
                 league_icon_span = Some(ratatui::text::Span::raw("RUGBY "));
             } else if upper_name.contains("EVENT") || upper_name.contains("PPV") {
                 league_icon_span = Some(ratatui::text::Span::raw("EVENT "));
-            } else if upper_name.contains("ESPN") || upper_name.contains("DAZN") || upper_name.contains("B/R") || upper_name.contains("BALLY") {
+            } else if upper_name.contains("ESPN")
+                || upper_name.contains("DAZN")
+                || upper_name.contains("B/R")
+                || upper_name.contains("BALLY")
+            {
                 league_icon_span = Some(ratatui::text::Span::raw("TV "));
             }
 
             if let Some(icon) = league_icon_span {
-                 spans.push(icon);
+                spans.push(icon);
             } else {
                 // Extended Auto-Discovery (Silent discovery, no icons needed if not matched above)
                 let name = parsed.display_name.to_uppercase();
-                if name.contains("FOOTBALL") || name.contains("LIGUE") || name.contains("BUNDESLIGA") || name.contains("SERIE A") {
-                    spans.push(ratatui::text::Span::styled("SOCCER ", Style::default().fg(Color::Rgb(200, 255, 200))));
+                if name.contains("FOOTBALL")
+                    || name.contains("LIGUE")
+                    || name.contains("BUNDESLIGA")
+                    || name.contains("SERIE A")
+                {
+                    spans.push(ratatui::text::Span::styled(
+                        "SOCCER ",
+                        Style::default().fg(Color::Rgb(200, 255, 200)),
+                    ));
                 } else if name.contains("BASKETBALL") || name.contains("EUROLEAGUE") {
-                    spans.push(ratatui::text::Span::styled("BASKET ", Style::default().fg(Color::Rgb(255, 140, 0))));
+                    spans.push(ratatui::text::Span::styled(
+                        "BASKET ",
+                        Style::default().fg(Color::Rgb(255, 140, 0)),
+                    ));
                 } else if name.contains("AUTO") || name.contains("MOTOR") {
                     spans.push(ratatui::text::Span::raw("RACE "));
                 } else if name.contains("CRICKET") || name.contains("IPL") {
@@ -366,21 +453,31 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
 
             // 2. Channel Number
             if let Some(ref cp) = parsed.channel_prefix {
-                 let num_only = cp.chars().filter(|c| c.is_digit(10)).collect::<String>();
-                 if !num_only.is_empty() {
-                     spans.push(ratatui::text::Span::styled(format!("{}: ", num_only), Style::default().fg(TEXT_DIM)));
-                 }
+                let num_only = cp
+                    .chars()
+                    .filter(|c| c.is_ascii_digit())
+                    .collect::<String>();
+                if !num_only.is_empty() {
+                    spans.push(ratatui::text::Span::styled(
+                        format!("{}: ", num_only),
+                        Style::default().fg(TEXT_DIM),
+                    ));
+                }
             }
 
             // 3. Favorite indicator
             let s_id = crate::api::get_id_str(&s.stream_id);
             if app.config.favorites.streams.contains(&s_id) {
-                spans.push(ratatui::text::Span::styled("* ", Style::default().fg(MATRIX_GREEN)));
+                spans.push(ratatui::text::Span::styled(
+                    "* ",
+                    Style::default().fg(MATRIX_GREEN),
+                ));
             }
 
             // 3. Country Flag
             if let Some(ref country) = parsed.country {
-                let is_us_en = country == "US" || country == "USA" || country == "AM" || country == "EN";
+                let is_us_en =
+                    country == "US" || country == "USA" || country == "AM" || country == "EN";
                 if !(app.config.playlist_mode.is_merica_variant() && is_us_en) {
                     let flag = country_flag(country);
                     if !flag.is_empty() {
@@ -390,26 +487,35 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
             }
 
             // 4. Name / Matchup
-            let is_league = parsed.country.as_ref().map(|cc| ["NBA", "NFL", "MLB", "NHL", "UFC", "SPORTS", "PPV"].contains(&cc.as_str())).unwrap_or(false);
-            
+            let is_league = parsed
+                .country
+                .as_ref()
+                .map(|cc| {
+                    ["NBA", "NFL", "MLB", "NHL", "UFC", "SPORTS", "PPV"].contains(&cc.as_str())
+                })
+                .unwrap_or(false);
+
             let score_data_for_color = app.get_score_for_stream(&parsed.display_name);
             let name_color = if is_league {
-                parsed.country.as_ref().map(|cc| country_color(cc)).unwrap_or(TEXT_PRIMARY)
+                parsed
+                    .country
+                    .as_ref()
+                    .map(|cc| country_color(cc))
+                    .unwrap_or(TEXT_PRIMARY)
             } else {
                 MATRIX_GREEN
             };
-            
-            
+
             // SPLIT TEAM COLORING
             if let Some(score) = score_data_for_color {
                 let h_color = crate::sports::get_team_color_with_fallback(&score.home_team, true);
                 let a_color = crate::sports::get_team_color_with_fallback(&score.away_team, false);
-                
+
                 let h_full = format!("{} [{}]", score.home_team, score.home_score);
                 let a_full = format!("[{}] {}", score.away_score, score.away_team);
 
                 let width = 28;
-                
+
                 let h_display = if h_full.len() > width {
                     let name_avail = width.saturating_sub(score.home_score.len() + 3);
                     let truncated_name = if score.home_team.len() > name_avail {
@@ -417,9 +523,13 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
                     } else {
                         score.home_team.clone()
                     };
-                    format!("{:>width$}", format!("{} [{}]", truncated_name, score.home_score), width=width)
+                    format!(
+                        "{:>width$}",
+                        format!("{} [{}]", truncated_name, score.home_score),
+                        width = width
+                    )
                 } else {
-                    format!("{:>width$}", h_full, width=width)
+                    format!("{:>width$}", h_full, width = width)
                 };
 
                 let a_display = if a_full.len() > width {
@@ -429,51 +539,64 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
                     } else {
                         score.away_team.clone()
                     };
-                    format!("{:<width$}", format!("[{}] {}", score.away_score, truncated_name), width=width)
+                    format!(
+                        "{:<width$}",
+                        format!("[{}] {}", score.away_score, truncated_name),
+                        width = width
+                    )
                 } else {
-                    format!("{:<width$}", a_full, width=width)
+                    format!("{:<width$}", a_full, width = width)
                 };
 
-                spans.push(ratatui::text::Span::styled(h_display, Style::default().fg(h_color).add_modifier(Modifier::BOLD)));
-                spans.push(ratatui::text::Span::styled(" vs ", Style::default().fg(TEXT_DIM)));
-                spans.push(ratatui::text::Span::styled(a_display, Style::default().fg(a_color).add_modifier(Modifier::BOLD)));
-                
-                 if let Some(q) = &parsed.quality {
-                     spans.push(ratatui::text::Span::styled(
-                         format!(" {} ", q.badge()),
-                         Style::default().fg(q.color()).add_modifier(Modifier::BOLD),
-                     ));
-                 }
-                 
-                 spans.push(ratatui::text::Span::raw("   "));
+                spans.push(ratatui::text::Span::styled(
+                    h_display,
+                    Style::default().fg(h_color).add_modifier(Modifier::BOLD),
+                ));
+                spans.push(ratatui::text::Span::styled(
+                    " vs ",
+                    Style::default().fg(TEXT_DIM),
+                ));
+                spans.push(ratatui::text::Span::styled(
+                    a_display,
+                    Style::default().fg(a_color).add_modifier(Modifier::BOLD),
+                ));
+
+                if let Some(q) = &parsed.quality {
+                    spans.push(ratatui::text::Span::styled(
+                        format!(" {} ", q.badge()),
+                        Style::default().fg(q.color()).add_modifier(Modifier::BOLD),
+                    ));
+                }
+
+                spans.push(ratatui::text::Span::raw("   "));
             } else {
                 // Standard rendering
-                let max_width = area.width.saturating_sub(4) as usize; 
+                let max_width = area.width.saturating_sub(4) as usize;
                 let mut display_name = parsed.display_name.clone();
                 let mut year_suffix = String::new();
-                
+
                 if let Some(y) = &parsed.year {
                     if !y.is_empty() {
                         let y_str = format!(" [{}]", y);
                         let total_len = display_name.len() + y_str.len();
-                        
+
                         if total_len > max_width {
                             let name_avail = max_width.saturating_sub(y_str.len());
                             if name_avail > 3 {
-                                display_name = format!("{}...", &display_name[..name_avail.saturating_sub(3)]);
+                                display_name =
+                                    format!("{}...", &display_name[..name_avail.saturating_sub(3)]);
                             } else {
                                 display_name = display_name.chars().take(name_avail).collect();
                             }
                         }
                         year_suffix = y_str;
                     }
-                } else {
-                    if display_name.len() > max_width {
-                         if max_width > 3 {
-                             display_name = format!("{}...", &display_name[..max_width.saturating_sub(3)]);
-                         } else {
-                             display_name = display_name.chars().take(max_width).collect();
-                         }
+                } else if display_name.len() > max_width {
+                    if max_width > 3 {
+                        display_name =
+                            format!("{}...", &display_name[..max_width.saturating_sub(3)]);
+                    } else {
+                        display_name = display_name.chars().take(max_width).collect();
                     }
                 }
 
@@ -486,44 +609,60 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
                     parsed.sports_event.as_ref(),
                     Style::default().fg(name_color),
                 );
-                
+
                 if !year_suffix.is_empty() {
-                   styled_name.push(ratatui::text::Span::styled(year_suffix, Style::default().fg(TEXT_SECONDARY)));
+                    styled_name.push(ratatui::text::Span::styled(
+                        year_suffix,
+                        Style::default().fg(TEXT_SECONDARY),
+                    ));
                 }
-                
+
                 spans.extend(styled_name);
             }
 
             // 5. Score/Clock Logic
             let score_data = app.get_score_for_stream(&parsed.display_name);
-            
-            let (final_is_live, final_is_ended, status_text, score_text) = if let Some(score) = score_data {
-                let is_active = score.status_state == "in";
-                let is_finished = score.status_state == "post";
-                let clock = if is_finished {
-                    "Final".to_string()
-                } else if is_active {
-                     if !score.display_clock.is_empty() && score.display_clock != "00:00" {
-                         score.display_clock.split(' ').next().unwrap_or(&score.display_clock).to_string()
-                     } else {
-                         "LIVE".to_string()
-                     }
+
+            let (final_is_live, final_is_ended, status_text, score_text) =
+                if let Some(score) = score_data {
+                    let is_active = score.status_state == "in";
+                    let is_finished = score.status_state == "post";
+                    let clock = if is_finished {
+                        "Final".to_string()
+                    } else if is_active {
+                        if !score.display_clock.is_empty() && score.display_clock != "00:00" {
+                            score
+                                .display_clock
+                                .split(' ')
+                                .next()
+                                .unwrap_or(&score.display_clock)
+                                .to_string()
+                        } else {
+                            "LIVE".to_string()
+                        }
+                    } else {
+                        score.status_detail.clone()
+                    };
+                    let display_score = format!("[{}-{}]", score.home_score, score.away_score);
+                    (is_active, is_finished, Some(clock), Some(display_score))
                 } else {
-                    score.status_detail.clone()
+                    (is_live, is_ended, None, None)
                 };
-                let display_score = format!("[{}-{}]", score.home_score, score.away_score);
-                (is_active, is_finished, Some(clock), Some(display_score))
-            } else {
-                (is_live, is_ended, None, None)
-            };
 
             if score_data.is_none() {
                 if let Some(clock) = status_text {
-                     let mut clock_style = Style::default().fg(Color::Rgb(255, 200, 80)).add_modifier(Modifier::BOLD);
-                     if final_is_ended {
-                         clock_style = Style::default().fg(TEXT_DIM).add_modifier(Modifier::CROSSED_OUT); 
-                     }
-                     spans.push(ratatui::text::Span::styled(format!(" [{}] ", clock), clock_style));
+                    let mut clock_style = Style::default()
+                        .fg(Color::Rgb(255, 200, 80))
+                        .add_modifier(Modifier::BOLD);
+                    if final_is_ended {
+                        clock_style = Style::default()
+                            .fg(TEXT_DIM)
+                            .add_modifier(Modifier::CROSSED_OUT);
+                    }
+                    spans.push(ratatui::text::Span::styled(
+                        format!(" [{}] ", clock),
+                        clock_style,
+                    ));
                 } else if let Some(st) = parsed.start_time {
                     let time_str = format!(" {} ", format_relative_time(st, &user_tz));
                     let mut time_style = Style::default().fg(TEXT_SECONDARY);
@@ -536,29 +675,55 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
 
             if score_data.is_none() {
                 if let Some(score) = score_text {
-                    spans.push(ratatui::text::Span::styled(score, Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD)));
+                    spans.push(ratatui::text::Span::styled(
+                        score,
+                        Style::default()
+                            .fg(TEXT_PRIMARY)
+                            .add_modifier(Modifier::BOLD),
+                    ));
                 }
             }
 
             // 6. Live / Ended Badges
             if final_is_live {
-                let live_color = if is_blink_on { Color::Rgb(255, 100, 100) } else { TEXT_DIM };
+                let live_color = if is_blink_on {
+                    Color::Rgb(255, 100, 100)
+                } else {
+                    TEXT_DIM
+                };
                 let dot = if is_blink_on { "● " } else { "  " };
-                spans.push(ratatui::text::Span::styled(dot, Style::default().fg(live_color)));
-                spans.push(ratatui::text::Span::styled("LIVE", Style::default().fg(live_color).add_modifier(Modifier::BOLD)));
+                spans.push(ratatui::text::Span::styled(
+                    dot,
+                    Style::default().fg(live_color),
+                ));
+                spans.push(ratatui::text::Span::styled(
+                    "LIVE",
+                    Style::default().fg(live_color).add_modifier(Modifier::BOLD),
+                ));
             } else if final_is_ended {
-                spans.push(ratatui::text::Span::styled(" ended", Style::default().fg(TEXT_DIM)));
+                spans.push(ratatui::text::Span::styled(
+                    " ended",
+                    Style::default().fg(TEXT_DIM),
+                ));
             }
 
             // 7. Location
             if parsed.sports_event.is_none() {
                 if let Some(loc) = &parsed.location {
-                    spans.push(ratatui::text::Span::styled(format!(" ({})", loc), Style::default().fg(TEXT_SECONDARY)));
+                    spans.push(ratatui::text::Span::styled(
+                        format!(" ({})", loc),
+                        Style::default().fg(TEXT_SECONDARY),
+                    ));
                 }
             }
 
             // 8. Network Health
-            let health = app.sports.stream_health_cache.get(&s_id).copied().or(s.latency_ms);
+            let health = app
+                .sports
+                .stream_health_cache
+                .get(&s_id)
+                .copied()
+                .or(s.latency_ms);
             spans.push(latency_to_bars(health));
 
             ListItem::new(Line::from(spans))
@@ -567,7 +732,8 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
 
     let title = format!("streams · {}", tz_display);
     let is_active = app.active_pane == crate::app::Pane::Streams;
-    let inner_area = crate::ui::common::render_matrix_box_active(f, area, &title, border_color, is_active);
+    let inner_area =
+        crate::ui::common::render_matrix_box_active(f, area, &title, border_color, is_active);
 
     // Empty state messaging
     if app.streams.is_empty() {
@@ -607,7 +773,9 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
     };
 
     // Render column headers
-    let header_style = Style::default().fg(TEXT_SECONDARY).add_modifier(Modifier::BOLD);
+    let header_style = Style::default()
+        .fg(TEXT_SECONDARY)
+        .add_modifier(Modifier::BOLD);
     let sep_line = "─".repeat(inner_area.width as usize);
     let header_text = vec![
         Line::from(vec![
@@ -623,7 +791,7 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
         .highlight_style(list_highlight_style())
         .highlight_symbol(" ▎");
 
-    let mut adjusted_state = app.stream_list_state.clone();
+    let mut adjusted_state = app.stream_list_state;
     if adjusted_start > 0 {
         adjusted_state.select(Some(selected - adjusted_start));
     }
@@ -637,11 +805,7 @@ pub fn render_global_search_pane(f: &mut Frame, app: &mut App, area: Rect) {
     let selected = app.selected_stream_index;
 
     let half_window = visible_height / 2;
-    let start = if selected > half_window {
-        selected - half_window
-    } else {
-        0
-    };
+    let start = selected.saturating_sub(half_window);
     let end = (start + visible_height + half_window).min(total);
     let adjusted_start = if end == total && end > visible_height + half_window {
         end.saturating_sub(visible_height + half_window)
@@ -663,12 +827,11 @@ pub fn render_global_search_pane(f: &mut Frame, app: &mut App, area: Rect) {
             let display_name = &s.name;
 
             let parsed = if let Some(ref cached) = s.cached_parsed {
-                 cached.as_ref().clone()
+                cached.as_ref().clone()
             } else {
                 crate::parser::parse_stream(display_name, app.provider_timezone.as_deref())
             };
             let mut spans = vec![];
-            
 
             let (mut styled_name, _) = stylize_channel_name(
                 &parsed.display_name,
@@ -679,27 +842,41 @@ pub fn render_global_search_pane(f: &mut Frame, app: &mut App, area: Rect) {
                 parsed.sports_event.as_ref(),
                 Style::default().fg(MATRIX_GREEN),
             );
-            
+
             if let Some(y) = &parsed.year {
                 if !y.is_empty() {
-                    styled_name.push(ratatui::text::Span::styled(format!(" [{}]", y), Style::default().fg(TEXT_SECONDARY)));
+                    styled_name.push(ratatui::text::Span::styled(
+                        format!(" [{}]", y),
+                        Style::default().fg(TEXT_SECONDARY),
+                    ));
                 }
             }
-            
+
             spans.extend(styled_name);
 
             if s.stream_type == "live" {
                 if let Some(st) = parsed.start_time {
                     let time_str = format!(" {} ", format_relative_time(st, &user_tz));
-                    spans.push(ratatui::text::Span::styled(time_str, Style::default().fg(TEXT_SECONDARY)));
+                    spans.push(ratatui::text::Span::styled(
+                        time_str,
+                        Style::default().fg(TEXT_SECONDARY),
+                    ));
                 }
             }
 
-            let health = app.sports.stream_health_cache.get(&s_id).copied().or(s.latency_ms);
+            let health = app
+                .sports
+                .stream_health_cache
+                .get(&s_id)
+                .copied()
+                .or(s.latency_ms);
             spans.push(latency_to_bars(health));
 
             if let Some(account) = &s.account_name {
-                spans.push(ratatui::text::Span::styled(format!(" [{}]", account), Style::default().fg(TEXT_DIM)));
+                spans.push(ratatui::text::Span::styled(
+                    format!(" [{}]", account),
+                    Style::default().fg(TEXT_DIM),
+                ));
             }
 
             ListItem::new(Line::from(spans))
@@ -707,9 +884,17 @@ pub fn render_global_search_pane(f: &mut Frame, app: &mut App, area: Rect) {
         .collect();
 
     let title = if app.search_state.query.is_empty() {
-        format!("search ({}) — type to filter", app.global_search_results.len())
+        format!(
+            "search ({}) — type to filter",
+            app.global_search_results.len()
+        )
     } else {
-        format!("search: \"{}\" ({}/{})", app.search_state.query, selected.saturating_add(1), app.global_search_results.len())
+        format!(
+            "search: \"{}\" ({}/{})",
+            app.search_state.query,
+            selected.saturating_add(1),
+            app.global_search_results.len()
+        )
     };
     let inner_area = crate::ui::common::render_matrix_box(f, area, &title, SOFT_GREEN);
 
@@ -717,7 +902,7 @@ pub fn render_global_search_pane(f: &mut Frame, app: &mut App, area: Rect) {
         .highlight_style(list_highlight_style())
         .highlight_symbol(" ▎");
 
-    let mut adjusted_state = app.global_search_list_state.clone();
+    let mut adjusted_state = app.global_search_list_state;
     if adjusted_start > 0 {
         adjusted_state.select(Some(selected - adjusted_start));
     }
@@ -727,9 +912,15 @@ pub fn render_global_search_pane(f: &mut Frame, app: &mut App, area: Rect) {
 
 fn latency_to_bars(latency: Option<u64>) -> ratatui::text::Span<'static> {
     match latency {
-        Some(l) if l < 200 => ratatui::text::Span::styled(" ▰▰▰", Style::default().fg(MATRIX_GREEN)),
-        Some(l) if l < 600 => ratatui::text::Span::styled(" ▰▰░", Style::default().fg(Color::Rgb(255, 200, 80))),
-        Some(_) => ratatui::text::Span::styled(" ▰░░", Style::default().fg(Color::Rgb(255, 100, 100))),
+        Some(l) if l < 200 => {
+            ratatui::text::Span::styled(" ▰▰▰", Style::default().fg(MATRIX_GREEN))
+        }
+        Some(l) if l < 600 => {
+            ratatui::text::Span::styled(" ▰▰░", Style::default().fg(Color::Rgb(255, 200, 80)))
+        }
+        Some(_) => {
+            ratatui::text::Span::styled(" ▰░░", Style::default().fg(Color::Rgb(255, 100, 100)))
+        }
         None => ratatui::text::Span::raw(""),
     }
 }
@@ -776,42 +967,66 @@ pub fn render_channel_detail_panel(f: &mut Frame, app: &mut App, area: Rect, bor
     // Show stream_id in summary header for easy channel identification
     let ch_id_str = crate::api::get_id_str(&s.stream_id);
     let summary_label = format!("Ch {} · Summary", ch_id_str);
-    lines.push(Line::from(vec![
-        Span::styled(summary_label, Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
-    ]));
+    lines.push(Line::from(vec![Span::styled(
+        summary_label,
+        Style::default()
+            .fg(MATRIX_GREEN)
+            .add_modifier(Modifier::BOLD),
+    )]));
     // Truncate display name to fit panel width
     let display = if parsed.display_name.chars().count() > w.saturating_sub(1) {
-        let s: String = parsed.display_name.chars().take(w.saturating_sub(2)).collect();
+        let s: String = parsed
+            .display_name
+            .chars()
+            .take(w.saturating_sub(2))
+            .collect();
         format!("{}…", s)
     } else {
         parsed.display_name.clone()
     };
-    lines.push(Line::from(Span::styled(display, value_style.add_modifier(Modifier::BOLD))));
+    lines.push(Line::from(Span::styled(
+        display,
+        value_style.add_modifier(Modifier::BOLD),
+    )));
     lines.push(Line::from(Span::styled("─".repeat(w), dim_style)));
 
     // ── Field Grid (JiraTUI 2-column fields) ──
     // Quality | Region on same row
-    let _quality_str = parsed.quality.as_ref()
+    let _quality_str = parsed
+        .quality
+        .as_ref()
         .map(|q| format!(" {} ", q.badge()))
         .unwrap_or_else(|| "—".to_string());
-    let region_str = parsed.country.as_ref()
+    let region_str = parsed
+        .country
+        .as_ref()
         .map(|c| {
             let flag = country_flag(c);
-            if !flag.is_empty() { format!("{} {}", flag, c) } else { c.clone() }
+            if !flag.is_empty() {
+                format!("{} {}", flag, c)
+            } else {
+                c.clone()
+            }
         })
         .unwrap_or_else(|| "—".to_string());
 
     // Quality label + Region label
     let half = w / 2;
     lines.push(Line::from(vec![
-        Span::styled(format!("{:<half$}", "Quality"), Style::default().fg(label_color)),
+        Span::styled(
+            format!("{:<half$}", "Quality"),
+            Style::default().fg(label_color),
+        ),
         Span::styled("Region", Style::default().fg(label_color)),
     ]));
     // Quality value + Region value
     let quality_span = if let Some(q) = &parsed.quality {
         Span::styled(
             format!("{:<half$}", format!(" {} ", q.badge())),
-            Style::default().fg(Color::Black).bg(q.color()).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Black)
+                .bg(q.color())
+                .add_modifier(Modifier::BOLD),
         )
     } else {
         Span::styled(format!("{:<half$}", "—"), dim_style)
@@ -823,45 +1038,66 @@ pub fn render_channel_detail_panel(f: &mut Frame, app: &mut App, area: Rect, bor
     lines.push(Line::from(Span::styled("─".repeat(w), dim_style)));
 
     // Category
-    let cat_display = s.category_id.as_ref().map(|cat_id| {
-        app.categories.iter()
-            .find(|c| &c.category_id == cat_id)
-            .map(|c| c.category_name.as_str())
-            .or_else(|| app.all_categories.iter()
+    let cat_display = s
+        .category_id
+        .as_ref()
+        .map(|cat_id| {
+            app.categories
+                .iter()
                 .find(|c| &c.category_id == cat_id)
-                .map(|c| c.category_name.as_str()))
-            .unwrap_or(cat_id.as_str())
-            .to_string()
-    }).unwrap_or_else(|| "—".to_string());
-    
-    lines.push(Line::from(Span::styled("Category", Style::default().fg(label_color))));
-    let cat_trunc = if cat_display.chars().count() > w { 
+                .map(|c| c.category_name.as_str())
+                .or_else(|| {
+                    app.all_categories
+                        .iter()
+                        .find(|c| &c.category_id == cat_id)
+                        .map(|c| c.category_name.as_str())
+                })
+                .unwrap_or(cat_id.as_str())
+                .to_string()
+        })
+        .unwrap_or_else(|| "—".to_string());
+
+    lines.push(Line::from(Span::styled(
+        "Category",
+        Style::default().fg(label_color),
+    )));
+    let cat_trunc = if cat_display.chars().count() > w {
         let s: String = cat_display.chars().take(w.saturating_sub(1)).collect();
-        format!("{}…", s) 
-    } else { cat_display };
+        format!("{}…", s)
+    } else {
+        cat_display
+    };
     lines.push(Line::from(Span::styled(cat_trunc, value_style)));
     lines.push(Line::from(Span::styled("─".repeat(w), dim_style)));
 
     // EPG Now Playing (own row)
     let s_id_for_epg = crate::api::get_id_str(&s.stream_id);
-    let now_playing = app.epg_cache.get(&s_id_for_epg)
-        .map(|s| s.clone())
+    let now_playing = app
+        .epg_cache
+        .get(&s_id_for_epg)
+        .cloned()
         .unwrap_or_else(|| "—".to_string());
-        
+
     let epg_trunc = if now_playing.chars().count() > w.saturating_sub(1) {
         let sc: String = now_playing.chars().take(w.saturating_sub(2)).collect();
         format!("{}…", sc)
-    } else { now_playing };
-    
-    lines.push(Line::from(Span::styled("Now Playing", Style::default().fg(label_color))));
+    } else {
+        now_playing
+    };
+
+    lines.push(Line::from(Span::styled(
+        "Now Playing",
+        Style::default().fg(label_color),
+    )));
     lines.push(Line::from(Span::styled(epg_trunc, value_style)));
     lines.push(Line::from(Span::styled("─".repeat(w), dim_style)));
 
     // Stream ID (own row)
     let sid = s_id_for_epg;
-    lines.push(Line::from(vec![
-        Span::styled("Stream ID", Style::default().fg(label_color)),
-    ]));
+    lines.push(Line::from(vec![Span::styled(
+        "Stream ID",
+        Style::default().fg(label_color),
+    )]));
     lines.push(Line::from(Span::styled(&sid, dim_style)));
     lines.push(Line::from(Span::styled("─".repeat(w), dim_style)));
 
@@ -869,7 +1105,8 @@ pub fn render_channel_detail_panel(f: &mut Frame, app: &mut App, area: Rect, bor
     let s_id = crate::api::get_id_str(&s.stream_id);
     let is_fav = app.config.favorites.streams.contains(&s_id);
     let fav_str = if is_fav { "* Yes" } else { "- No" };
-    let rating_str = s.rating
+    let rating_str = s
+        .rating
         .filter(|r| *r > 0.0)
         .map(|r| {
             let stars = "*".repeat((r / 2.0).ceil() as usize);
@@ -879,12 +1116,20 @@ pub fn render_channel_detail_panel(f: &mut Frame, app: &mut App, area: Rect, bor
         .unwrap_or_else(|| "—".to_string());
 
     lines.push(Line::from(vec![
-        Span::styled(format!("{:<half$}", "Favorite"), Style::default().fg(label_color)),
+        Span::styled(
+            format!("{:<half$}", "Favorite"),
+            Style::default().fg(label_color),
+        ),
         Span::styled("Rating", Style::default().fg(label_color)),
     ]));
     lines.push(Line::from(vec![
         if is_fav {
-            Span::styled(format!("{:<half$}", fav_str), Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD))
+            Span::styled(
+                format!("{:<half$}", fav_str),
+                Style::default()
+                    .fg(MATRIX_GREEN)
+                    .add_modifier(Modifier::BOLD),
+            )
         } else {
             Span::styled(format!("{:<half$}", fav_str), dim_style)
         },
@@ -893,23 +1138,32 @@ pub fn render_channel_detail_panel(f: &mut Frame, app: &mut App, area: Rect, bor
     lines.push(Line::from(Span::styled("─".repeat(w), dim_style)));
 
     // Added + Account row
-    let added_str = s.added.as_ref()
+    let added_str = s
+        .added
+        .as_ref()
         .filter(|a| !a.is_empty())
         .map(|a| {
             if let Ok(ts) = a.parse::<i64>() {
                 chrono::DateTime::from_timestamp(ts, 0)
                     .map(|dt| dt.format("%Y-%m-%d").to_string())
                     .unwrap_or_else(|| a.clone())
-            } else { a.clone() }
+            } else {
+                a.clone()
+            }
         })
         .unwrap_or_else(|| "—".to_string());
-    let acct_str = s.account_name.as_ref()
+    let acct_str = s
+        .account_name
+        .as_ref()
         .filter(|a| !a.is_empty())
         .cloned()
         .unwrap_or_else(|| "—".to_string());
 
     lines.push(Line::from(vec![
-        Span::styled(format!("{:<half$}", "Added"), Style::default().fg(label_color)),
+        Span::styled(
+            format!("{:<half$}", "Added"),
+            Style::default().fg(label_color),
+        ),
         Span::styled("Account", Style::default().fg(label_color)),
     ]));
     lines.push(Line::from(vec![
@@ -927,7 +1181,10 @@ pub fn render_channel_detail_panel(f: &mut Frame, app: &mut App, area: Rect, bor
         } else {
             ("Poor", Color::Rgb(255, 100, 100))
         };
-        lines.push(Line::from(Span::styled("Network", Style::default().fg(label_color))));
+        lines.push(Line::from(Span::styled(
+            "Network",
+            Style::default().fg(label_color),
+        )));
         lines.push(Line::from(Span::styled(
             format!("{} ({}ms)", label, lat),
             Style::default().fg(color),
@@ -942,7 +1199,6 @@ pub fn render_channel_detail_panel(f: &mut Frame, app: &mut App, area: Rect, bor
 
     f.render_widget(Paragraph::new(lines), inner);
 }
-
 
 pub fn render_stream_details_pane(f: &mut Frame, app: &mut App, area: Rect, border_color: Color) {
     let title = " match intelligence ";
@@ -968,7 +1224,7 @@ pub fn render_stream_details_pane(f: &mut Frame, app: &mut App, area: Rect, bord
     } else {
         parse_stream(&s.name, app.provider_timezone.as_deref())
     };
-    
+
     let score_data = app.get_score_for_stream(&parsed.display_name);
     let event = parsed.sports_event.clone();
 
@@ -976,19 +1232,33 @@ pub fn render_stream_details_pane(f: &mut Frame, app: &mut App, area: Rect, bord
     if event.is_none() && score_data.is_none() {
         let user_tz_str = app.config.get_user_timezone();
         let user_tz: Tz = user_tz_str.parse().unwrap_or(chrono_tz::UTC);
-        let mut lines = vec![
-            Line::from(Span::styled(&parsed.display_name, Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD))),
-        ];
+        let mut lines = vec![Line::from(Span::styled(
+            &parsed.display_name,
+            Style::default()
+                .fg(TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        ))];
         if let Some(st) = parsed.start_time {
             lines.push(Line::from(vec![
                 Span::styled("⏰ ", Style::default().fg(MATRIX_GREEN)),
-                Span::styled(format_relative_time(st, &user_tz), Style::default().fg(MATRIX_GREEN)),
+                Span::styled(
+                    format_relative_time(st, &user_tz),
+                    Style::default().fg(MATRIX_GREEN),
+                ),
             ]));
         } else {
-            lines.push(Line::from(Span::styled("No live match data", Style::default().fg(TEXT_DIM))));
+            lines.push(Line::from(Span::styled(
+                "No live match data",
+                Style::default().fg(TEXT_DIM),
+            )));
         }
         lines.push(Line::from(vec![
-            Span::styled("enter", Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "enter",
+                Style::default()
+                    .fg(MATRIX_GREEN)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" to watch", Style::default().fg(TEXT_SECONDARY)),
         ]));
         f.render_widget(Paragraph::new(lines), inner_area);
@@ -997,7 +1267,7 @@ pub fn render_stream_details_pane(f: &mut Frame, app: &mut App, area: Rect, bord
 
     let (team1, team2) = if let Some(ref ev) = event {
         (ev.team1.clone(), ev.team2.clone())
-    } else if let Some(ref sd) = score_data {
+    } else if let Some(sd) = score_data {
         (sd.home_team.clone(), sd.away_team.clone())
     } else {
         return;
@@ -1005,60 +1275,86 @@ pub fn render_stream_details_pane(f: &mut Frame, app: &mut App, area: Rect, bord
 
     let sub_chunks = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage(55),
-            Constraint::Percentage(45),
-        ])
+        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
         .split(inner_area);
 
     // --- LEFT SIDE ---
     let mut left = Vec::new();
-    
+
     let (h_score, a_score, _h_abbr, _a_abbr) = if let Some(score) = score_data {
-        (score.home_score.as_str(), score.away_score.as_str(), 
-         score.home_abbr.as_str(), score.away_abbr.as_str())
+        (
+            score.home_score.as_str(),
+            score.away_score.as_str(),
+            score.home_abbr.as_str(),
+            score.away_abbr.as_str(),
+        )
     } else {
         ("-", "-", "", "")
     };
-    
+
     let h_num: i32 = h_score.parse().unwrap_or(0);
     let a_num: i32 = a_score.parse().unwrap_or(0);
-    
-    let is_game_active = score_data.map(|s| s.status_state == "in" || s.status_state == "post").unwrap_or(false);
+
+    let is_game_active = score_data
+        .map(|s| s.status_state == "in" || s.status_state == "post")
+        .unwrap_or(false);
     let has_scoring = h_num > 0 || a_num > 0;
 
     if let Some(score) = score_data {
         if score.status_state == "in" {
-            let display_clock = if !score.display_clock.is_empty() && score.display_clock != "00:00" {
+            let display_clock = if !score.display_clock.is_empty() && score.display_clock != "00:00"
+            {
                 format!("{} — {}", score.display_clock, score.status_detail)
             } else {
                 score.status_detail.clone()
             };
-            
+
             left.push(Line::from(vec![
                 Span::styled("⏱ ", Style::default().fg(Color::Rgb(255, 100, 100))),
-                Span::styled(display_clock, Style::default().fg(Color::Rgb(255, 150, 150)).add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    display_clock,
+                    Style::default()
+                        .fg(Color::Rgb(255, 150, 150))
+                        .add_modifier(Modifier::BOLD),
+                ),
             ]));
         } else if score.status_state == "post" {
-            left.push(Line::from(vec![
-                Span::styled("✓ final", Style::default().fg(TEXT_SECONDARY)),
-            ]));
+            left.push(Line::from(vec![Span::styled(
+                "✓ final",
+                Style::default().fg(TEXT_SECONDARY),
+            )]));
         }
     }
 
-    let mut team1_spans = vec![
-        Span::styled(&team1, Style::default().fg(crate::sports::get_team_color_with_fallback(&team1, true)).add_modifier(Modifier::BOLD)),
-    ];
+    let mut team1_spans = vec![Span::styled(
+        &team1,
+        Style::default()
+            .fg(crate::sports::get_team_color_with_fallback(&team1, true))
+            .add_modifier(Modifier::BOLD),
+    )];
     if has_scoring || is_game_active {
-        team1_spans.push(Span::styled(format!("  {} ", h_score), Style::default().fg(Color::Rgb(255, 200, 80)).add_modifier(Modifier::BOLD)));
+        team1_spans.push(Span::styled(
+            format!("  {} ", h_score),
+            Style::default()
+                .fg(Color::Rgb(255, 200, 80))
+                .add_modifier(Modifier::BOLD),
+        ));
     }
     left.push(Line::from(team1_spans));
-    
-    let mut team2_spans = vec![
-        Span::styled(&team2, Style::default().fg(crate::sports::get_team_color_with_fallback(&team2, false)).add_modifier(Modifier::BOLD)),
-    ];
+
+    let mut team2_spans = vec![Span::styled(
+        &team2,
+        Style::default()
+            .fg(crate::sports::get_team_color_with_fallback(&team2, false))
+            .add_modifier(Modifier::BOLD),
+    )];
     if has_scoring || is_game_active {
-        team2_spans.push(Span::styled(format!("  {} ", a_score), Style::default().fg(Color::Rgb(255, 200, 80)).add_modifier(Modifier::BOLD)));
+        team2_spans.push(Span::styled(
+            format!("  {} ", a_score),
+            Style::default()
+                .fg(Color::Rgb(255, 200, 80))
+                .add_modifier(Modifier::BOLD),
+        ));
     }
     left.push(Line::from(team2_spans));
 
@@ -1066,55 +1362,89 @@ pub fn render_stream_details_pane(f: &mut Frame, app: &mut App, area: Rect, bord
 
     // --- RIGHT SIDE ---
     let mut right = Vec::new();
-    
+
     if let Some(score) = score_data {
         if let (Some(hwp), Some(awp)) = (score.home_win_pct, score.away_win_pct) {
             right.push(Line::from(vec![
                 Span::styled("odds ", Style::default().fg(TEXT_SECONDARY)),
-                Span::styled(format!("{} ", score.home_abbr), Style::default().fg(TEXT_PRIMARY)),
-                Span::styled(format!("{:.0}%", hwp * 100.0), Style::default().fg(if hwp > 0.5 { MATRIX_GREEN } else { TEXT_SECONDARY })),
+                Span::styled(
+                    format!("{} ", score.home_abbr),
+                    Style::default().fg(TEXT_PRIMARY),
+                ),
+                Span::styled(
+                    format!("{:.0}%", hwp * 100.0),
+                    Style::default().fg(if hwp > 0.5 {
+                        MATRIX_GREEN
+                    } else {
+                        TEXT_SECONDARY
+                    }),
+                ),
                 Span::styled(" · ", Style::default().fg(TEXT_DIM)),
-                Span::styled(format!("{} ", score.away_abbr), Style::default().fg(TEXT_PRIMARY)),
-                Span::styled(format!("{:.0}%", awp * 100.0), Style::default().fg(if awp > 0.5 { MATRIX_GREEN } else { TEXT_SECONDARY })),
+                Span::styled(
+                    format!("{} ", score.away_abbr),
+                    Style::default().fg(TEXT_PRIMARY),
+                ),
+                Span::styled(
+                    format!("{:.0}%", awp * 100.0),
+                    Style::default().fg(if awp > 0.5 {
+                        MATRIX_GREEN
+                    } else {
+                        TEXT_SECONDARY
+                    }),
+                ),
             ]));
         }
-        
+
         if let Some(series) = &score.series_summary {
             right.push(Line::from(vec![
                 Span::styled("series ", Style::default().fg(TEXT_SECONDARY)),
                 Span::styled(series, Style::default().fg(TEXT_PRIMARY)),
             ]));
         }
-        
+
         if let Some(scorer) = &score.top_scorer {
             right.push(Line::from(vec![
                 Span::styled("star ", Style::default().fg(TEXT_SECONDARY)),
                 Span::styled(scorer, Style::default().fg(TEXT_PRIMARY)),
             ]));
         }
-        
+
         if score.status_state == "post" {
             if let Some(hl) = &score.headline {
-                let truncated = if hl.len() > 45 { format!("{}...", &hl[..42]) } else { hl.clone() };
+                let truncated = if hl.len() > 45 {
+                    format!("{}...", &hl[..42])
+                } else {
+                    hl.clone()
+                };
                 right.push(Line::from(vec![
                     Span::styled("recap ", Style::default().fg(TEXT_SECONDARY)),
                     Span::styled(truncated, Style::default().fg(TEXT_PRIMARY)),
                 ]));
             }
         }
-        
+
         if score.status_state == "in" {
             if let Some(lp) = &score.last_play {
-                let truncated = if lp.len() > 35 { format!("{}...", &lp[..32]) } else { lp.clone() };
+                let truncated = if lp.len() > 35 {
+                    format!("{}...", &lp[..32])
+                } else {
+                    lp.clone()
+                };
                 right.push(Line::from(vec![
                     Span::styled("▶ ", Style::default().fg(MATRIX_GREEN)),
                     Span::styled(truncated, Style::default().fg(TEXT_PRIMARY)),
                 ]));
             }
         }
-        
+
         if !score.broadcasts.is_empty() {
-            let channels = score.broadcasts.iter().take(2).cloned().collect::<Vec<_>>().join(", ");
+            let channels = score
+                .broadcasts
+                .iter()
+                .take(2)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ");
             right.push(Line::from(vec![
                 Span::styled("tv ", Style::default().fg(TEXT_SECONDARY)),
                 Span::styled(channels, Style::default().fg(TEXT_PRIMARY)),
@@ -1123,7 +1453,7 @@ pub fn render_stream_details_pane(f: &mut Frame, app: &mut App, area: Rect, bord
     } else {
         let user_tz_str = app.config.get_user_timezone();
         let user_tz: Tz = user_tz_str.parse().unwrap_or(chrono_tz::UTC);
-        
+
         if let Some(st) = parsed.start_time {
             let time_str = format_relative_time(st, &user_tz);
             right.push(Line::from(vec![
@@ -1134,7 +1464,12 @@ pub fn render_stream_details_pane(f: &mut Frame, app: &mut App, area: Rect, bord
     }
 
     right.push(Line::from(vec![
-        Span::styled("enter", Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            "enter",
+            Style::default()
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled(" to watch", Style::default().fg(TEXT_SECONDARY)),
     ]));
     f.render_widget(Paragraph::new(right), sub_chunks[1]);

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -29,14 +29,6 @@ pub fn render_help_popup(f: &mut Frame, area: Rect) {
             Span::styled("switch panes", Style::default().fg(TEXT_SECONDARY)),
         ]),
         Line::from(vec![
-            Span::styled("  PgDn/PgUp   ", Style::default().fg(MATRIX_GREEN)),
-            Span::styled("page down / page up", Style::default().fg(TEXT_SECONDARY)),
-        ]),
-        Line::from(vec![
-            Span::styled("  ctrl+d/u    ", Style::default().fg(MATRIX_GREEN)),
-            Span::styled("half page down / up", Style::default().fg(TEXT_SECONDARY)),
-        ]),
-        Line::from(vec![
             Span::styled("  Home/End    ", Style::default().fg(MATRIX_GREEN)),
             Span::styled("jump to top / bottom", Style::default().fg(TEXT_SECONDARY)),
         ]),

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -10,7 +10,7 @@ use crate::ui::colors::{MATRIX_GREEN, SOFT_GREEN, HIGHLIGHT_BG, TEXT_PRIMARY, TE
 use crate::ui::utils::centered_rect;
 
 pub fn render_help_popup(f: &mut Frame, area: Rect) {
-    let area = centered_rect(60, 60, area);
+    let area = centered_rect(64, 82, area);
     f.render_widget(Clear, area);
 
     let inner_area = crate::ui::common::render_composite_block(f, area, Some("keyboard shortcuts"));
@@ -27,6 +27,39 @@ pub fn render_help_popup(f: &mut Frame, area: Rect) {
         Line::from(vec![
             Span::styled("  ←→ / h/l   ", Style::default().fg(MATRIX_GREEN)),
             Span::styled("switch panes", Style::default().fg(TEXT_SECONDARY)),
+        ]),
+        Line::from(vec![
+            Span::styled("  PgDn/PgUp   ", Style::default().fg(MATRIX_GREEN)),
+            Span::styled("page down / page up", Style::default().fg(TEXT_SECONDARY)),
+        ]),
+        Line::from(vec![
+            Span::styled("  ctrl+d/u    ", Style::default().fg(MATRIX_GREEN)),
+            Span::styled("half page down / up", Style::default().fg(TEXT_SECONDARY)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Home/End    ", Style::default().fg(MATRIX_GREEN)),
+            Span::styled("jump to top / bottom", Style::default().fg(TEXT_SECONDARY)),
+        ]),
+        Line::from(vec![
+            Span::styled("  0           ", Style::default().fg(MATRIX_GREEN)),
+            Span::styled(
+                "jump to top where supported",
+                Style::default().fg(TEXT_SECONDARY),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  g           ", Style::default().fg(MATRIX_GREEN)),
+            Span::styled(
+                "category grid or live add-to-group",
+                Style::default().fg(TEXT_SECONDARY),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  G           ", Style::default().fg(MATRIX_GREEN)),
+            Span::styled(
+                "bottom on VOD/series lists, groups on live",
+                Style::default().fg(TEXT_SECONDARY),
+            ),
         ]),
         Line::from(vec![
             Span::styled("  enter       ", Style::default().fg(MATRIX_GREEN)),
@@ -50,12 +83,12 @@ pub fn render_help_popup(f: &mut Frame, area: Rect) {
             Span::styled("search current view", Style::default().fg(TEXT_SECONDARY)),
         ]),
         Line::from(vec![
-            Span::styled("  f           ", Style::default().fg(MATRIX_GREEN)),
-            Span::styled("toggle filter active/all", Style::default().fg(TEXT_SECONDARY)),
+            Span::styled("  / or f      ", Style::default().fg(MATRIX_GREEN)),
+            Span::styled("search current view", Style::default().fg(TEXT_SECONDARY)),
         ]),
         Line::from(vec![
             Span::styled("  v           ", Style::default().fg(MATRIX_GREEN)),
-            Span::styled("toggle favorite", Style::default().fg(TEXT_SECONDARY)),
+            Span::styled("toggle live favorite", Style::default().fg(TEXT_SECONDARY)),
         ]),
         Line::from(vec![
             Span::styled("  m           ", Style::default().fg(MATRIX_GREEN)),
@@ -372,14 +405,17 @@ pub fn render_play_details_popup(f: &mut Frame, app: &App, area: Rect) {
     let mut details = Vec::new();
     let mut metadata_found = false;
 
-    if app.current_screen == CurrentScreen::SeriesStreams && app.active_pane == Pane::Episodes {
-        if !app.series_episodes.is_empty() {
-            let ep = &app.series_episodes[app.selected_series_episode_index.min(app.series_episodes.len() - 1)];
-            if let Some(info) = &ep.info {
-                if let Some(map) = info.as_object() {
-                    add_metadata_lines(&mut details, map);
-                    metadata_found = true;
-                }
+    if app.current_screen == CurrentScreen::SeriesStreams
+        && app.active_pane == Pane::Episodes
+        && !app.series_episodes.is_empty()
+    {
+        let ep = &app.series_episodes[app
+            .selected_series_episode_index
+            .min(app.series_episodes.len() - 1)];
+        if let Some(info) = &ep.info {
+            if let Some(map) = info.as_object() {
+                add_metadata_lines(&mut details, map);
+                metadata_found = true;
             }
         }
     }
@@ -399,14 +435,19 @@ pub fn render_play_details_popup(f: &mut Frame, app: &App, area: Rect) {
                 if !metadata_found {
                     add_metadata_lines(&mut details, map);
                     metadata_found = true;
-                } else {
-                    if !details.iter().any(|l| l.spans.iter().any(|s| s.content.contains("cast"))) {
-                        if let Some(cast) = map.get("cast").and_then(|v| v.as_str()).or_else(|| map.get("actors").and_then(|v| v.as_str())) {
-                            details.push(Line::from(vec![
-                                Span::styled("cast     ", Style::default().fg(TEXT_SECONDARY)),
-                                Span::styled(cast, Style::default().fg(MATRIX_GREEN)),
-                            ]));
-                        }
+                } else if !details
+                    .iter()
+                    .any(|l| l.spans.iter().any(|s| s.content.contains("cast")))
+                {
+                    if let Some(cast) = map
+                        .get("cast")
+                        .and_then(|v| v.as_str())
+                        .or_else(|| map.get("actors").and_then(|v| v.as_str()))
+                    {
+                        details.push(Line::from(vec![
+                            Span::styled("cast     ", Style::default().fg(TEXT_SECONDARY)),
+                            Span::styled(cast, Style::default().fg(MATRIX_GREEN)),
+                        ]));
                     }
                 }
             }
@@ -581,7 +622,7 @@ pub fn render_cast_picker_popup(f: &mut Frame, app: &App, area: Rect) {
             })
             .collect();
 
-        let mut list_state = app.cast_device_list_state.clone();
+        let mut list_state = app.cast_device_list_state;
         let list = List::new(items)
             .highlight_style(Style::default().bg(HIGHLIGHT_BG).fg(MATRIX_GREEN).add_modifier(Modifier::BOLD))
             .highlight_symbol(" ▎");

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -1,3 +1,8 @@
+use crate::app::{App, CurrentScreen, Guide, Pane};
+use crate::ui::colors::{
+    HIGHLIGHT_BG, MATRIX_GREEN, SOFT_GREEN, TEXT_DIM, TEXT_PRIMARY, TEXT_SECONDARY,
+};
+use crate::ui::utils::centered_rect;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
@@ -5,9 +10,6 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, Clear, List, ListItem, Paragraph, Wrap},
     Frame,
 };
-use crate::app::{App, CurrentScreen, Guide, Pane};
-use crate::ui::colors::{MATRIX_GREEN, SOFT_GREEN, HIGHLIGHT_BG, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_DIM};
-use crate::ui::utils::centered_rect;
 
 pub fn render_help_popup(f: &mut Frame, area: Rect) {
     let area = centered_rect(64, 82, area);
@@ -16,9 +18,12 @@ pub fn render_help_popup(f: &mut Frame, area: Rect) {
     let inner_area = crate::ui::common::render_composite_block(f, area, Some("keyboard shortcuts"));
 
     let help_text = vec![
-        Line::from(vec![
-            Span::styled("  navigation", Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD)),
-        ]),
+        Line::from(vec![Span::styled(
+            "  navigation",
+            Style::default()
+                .fg(TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from(""),
         Line::from(vec![
             Span::styled("  ↑↓ / j/k   ", Style::default().fg(MATRIX_GREEN)),
@@ -66,9 +71,12 @@ pub fn render_help_popup(f: &mut Frame, area: Rect) {
             Span::styled("quit", Style::default().fg(TEXT_SECONDARY)),
         ]),
         Line::from(""),
-        Line::from(vec![
-            Span::styled("  features", Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD)),
-        ]),
+        Line::from(vec![Span::styled(
+            "  features",
+            Style::default()
+                .fg(TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from(""),
         Line::from(vec![
             Span::styled("  ctrl+space  ", Style::default().fg(MATRIX_GREEN)),
@@ -95,9 +103,10 @@ pub fn render_help_popup(f: &mut Frame, area: Rect) {
             Span::styled("settings", Style::default().fg(TEXT_SECONDARY)),
         ]),
         Line::from(""),
-        Line::from(vec![
-            Span::styled("  press esc to close", Style::default().fg(TEXT_DIM)),
-        ]),
+        Line::from(vec![Span::styled(
+            "  press esc to close",
+            Style::default().fg(TEXT_DIM),
+        )]),
     ];
 
     f.render_widget(
@@ -120,12 +129,16 @@ pub fn render_guide_popup(f: &mut Frame, app: &App, area: Rect) {
                 if line.starts_with("# ") {
                     Line::from(Span::styled(
                         line.trim_start_matches("# ").trim(),
-                        Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD),
+                        Style::default()
+                            .fg(TEXT_PRIMARY)
+                            .add_modifier(Modifier::BOLD),
                     ))
                 } else if line.starts_with("## ") {
                     Line::from(Span::styled(
                         line.trim_start_matches("## ").trim(),
-                        Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD),
+                        Style::default()
+                            .fg(MATRIX_GREEN)
+                            .add_modifier(Modifier::BOLD),
                     ))
                 } else if line.starts_with("### ") {
                     Line::from(Span::styled(
@@ -150,7 +163,10 @@ pub fn render_guide_popup(f: &mut Frame, app: &App, area: Rect) {
                         match c {
                             '*' => {
                                 if !current_text.is_empty() {
-                                    spans.push(Span::styled(current_text.clone(), Style::default().fg(TEXT_SECONDARY)));
+                                    spans.push(Span::styled(
+                                        current_text.clone(),
+                                        Style::default().fg(TEXT_SECONDARY),
+                                    ));
                                     current_text.clear();
                                 }
                                 if chars.peek() == Some(&'*') {
@@ -171,7 +187,9 @@ pub fn render_guide_popup(f: &mut Frame, app: &App, area: Rect) {
                                     }
                                     spans.push(Span::styled(
                                         bold_content,
-                                        Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)
+                                        Style::default()
+                                            .fg(MATRIX_GREEN)
+                                            .add_modifier(Modifier::BOLD),
                                     ));
                                 } else {
                                     let mut italic_content = String::new();
@@ -185,13 +203,18 @@ pub fn render_guide_popup(f: &mut Frame, app: &App, area: Rect) {
                                     }
                                     spans.push(Span::styled(
                                         italic_content,
-                                        Style::default().fg(TEXT_DIM).add_modifier(Modifier::ITALIC)
+                                        Style::default()
+                                            .fg(TEXT_DIM)
+                                            .add_modifier(Modifier::ITALIC),
                                     ));
                                 }
                             }
                             '`' => {
                                 if !current_text.is_empty() {
-                                    spans.push(Span::styled(current_text.clone(), Style::default().fg(TEXT_SECONDARY)));
+                                    spans.push(Span::styled(
+                                        current_text.clone(),
+                                        Style::default().fg(TEXT_SECONDARY),
+                                    ));
                                     current_text.clear();
                                 }
                                 let mut code_content = String::new();
@@ -205,7 +228,9 @@ pub fn render_guide_popup(f: &mut Frame, app: &App, area: Rect) {
                                 }
                                 spans.push(Span::styled(
                                     code_content,
-                                    Style::default().fg(MATRIX_GREEN).bg(ratatui::style::Color::Rgb(20, 20, 20))
+                                    Style::default()
+                                        .fg(MATRIX_GREEN)
+                                        .bg(ratatui::style::Color::Rgb(20, 20, 20)),
                                 ));
                             }
                             _ => {
@@ -213,9 +238,12 @@ pub fn render_guide_popup(f: &mut Frame, app: &App, area: Rect) {
                             }
                         }
                     }
-                    
+
                     if !current_text.is_empty() {
-                        spans.push(Span::styled(current_text, Style::default().fg(TEXT_SECONDARY)));
+                        spans.push(Span::styled(
+                            current_text,
+                            Style::default().fg(TEXT_SECONDARY),
+                        ));
                     }
 
                     Line::from(spans)
@@ -255,9 +283,9 @@ pub fn render_content_type_selection(f: &mut Frame, app: &mut App, area: Rect) {
 
     // 3 options - Sports temporarily hidden
     let options: Vec<(usize, &str, &str, &str, &str)> = vec![
-        (0, "[1]", "►", "Live Channels",  "real-time TV broadcasts"),
-        (1, "[2]", "▸", "Movies (VOD)",   "on-demand movie library"),
-        (2, "[3]", "▸", "TV Series",      "episodic content"),
+        (0, "[1]", "►", "Live Channels", "real-time TV broadcasts"),
+        (1, "[2]", "▸", "Movies (VOD)", "on-demand movie library"),
+        (2, "[3]", "▸", "TV Series", "episodic content"),
     ];
 
     let items: Vec<ListItem> = options
@@ -265,12 +293,16 @@ pub fn render_content_type_selection(f: &mut Frame, app: &mut App, area: Rect) {
         .map(|(i, badge, icon, label, sub)| {
             let is_sel = *i == selected;
             let key_style = if is_sel {
-                Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(MATRIX_GREEN)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(TEXT_DIM)
             };
             let label_style = if is_sel {
-                Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(MATRIX_GREEN)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(TEXT_PRIMARY)
             };
@@ -287,7 +319,12 @@ pub fn render_content_type_selection(f: &mut Frame, app: &mut App, area: Rect) {
     list_state.select(Some(selected));
     f.render_stateful_widget(
         List::new(items)
-            .highlight_style(Style::default().bg(HIGHLIGHT_BG).fg(MATRIX_GREEN).add_modifier(Modifier::BOLD))
+            .highlight_style(
+                Style::default()
+                    .bg(HIGHLIGHT_BG)
+                    .fg(MATRIX_GREEN)
+                    .add_modifier(Modifier::BOLD),
+            )
             .highlight_symbol(""),
         layout[0],
         &mut list_state,
@@ -317,24 +354,46 @@ pub fn render_content_type_selection(f: &mut Frame, app: &mut App, area: Rect) {
 
     // Key hints bar
     let hints = Line::from(vec![
-        Span::styled("enter", Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            "enter",
+            Style::default()
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled(" open  ", Style::default().fg(TEXT_SECONDARY)),
-        Span::styled("↑↓", Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            "↑↓",
+            Style::default()
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled(" navigate  ", Style::default().fg(TEXT_SECONDARY)),
-        Span::styled("esc", Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            "esc",
+            Style::default()
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled(" back  ", Style::default().fg(TEXT_SECONDARY)),
-        Span::styled("R", Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            "R",
+            Style::default()
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled(" refresh", Style::default().fg(TEXT_SECONDARY)),
     ]);
-    f.render_widget(
-        Paragraph::new(hints).alignment(Alignment::Left),
-        layout[3],
-    );
+    f.render_widget(Paragraph::new(hints).alignment(Alignment::Left), layout[3]);
 }
 
 pub fn render_error_popup(f: &mut Frame, area: Rect, error: &str) {
     let block = Block::default()
-        .title(Span::styled(" error ", Style::default().fg(ratatui::style::Color::Rgb(255, 100, 100)).add_modifier(Modifier::BOLD)))
+        .title(Span::styled(
+            " error ",
+            Style::default()
+                .fg(ratatui::style::Color::Rgb(255, 100, 100))
+                .add_modifier(Modifier::BOLD),
+        ))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(ratatui::style::Color::Rgb(255, 100, 100)));
@@ -377,7 +436,9 @@ pub fn render_play_details_popup(f: &mut Frame, app: &App, area: Rect) {
         .split(inner);
 
     if let Some(title) = &app.pending_play_title {
-        let display_title = if app.current_screen == CurrentScreen::SeriesStreams && app.active_pane == Pane::Episodes {
+        let display_title = if app.current_screen == CurrentScreen::SeriesStreams
+            && app.active_pane == Pane::Episodes
+        {
             if let Some(stream) = app.series_streams.get(app.selected_series_stream_index) {
                 format!("{} - {}", stream.name, title)
             } else {
@@ -388,9 +449,14 @@ pub fn render_play_details_popup(f: &mut Frame, app: &App, area: Rect) {
         };
 
         f.render_widget(
-            Paragraph::new(Span::styled(&display_title, Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD)))
-                .alignment(Alignment::Center),
-            chunks[0]
+            Paragraph::new(Span::styled(
+                &display_title,
+                Style::default()
+                    .fg(TEXT_PRIMARY)
+                    .add_modifier(Modifier::BOLD),
+            ))
+            .alignment(Alignment::Center),
+            chunks[0],
         );
     }
 
@@ -447,54 +513,66 @@ pub fn render_play_details_popup(f: &mut Frame, app: &App, area: Rect) {
     }
 
     if !metadata_found {
-        details.push(Line::from(vec![
-            Span::styled("No additional metadata available.", Style::default().fg(TEXT_DIM))
-        ]));
+        details.push(Line::from(vec![Span::styled(
+            "No additional metadata available.",
+            Style::default().fg(TEXT_DIM),
+        )]));
     }
 
     f.render_widget(
         Paragraph::new(details)
             .wrap(Wrap { trim: true })
             .block(Block::default().borders(Borders::NONE)),
-        chunks[1]
+        chunks[1],
     );
 
-    let controls = Paragraph::new(vec![
-        Line::from(vec![
-            Span::styled("enter", Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
-            Span::styled(" play   ", Style::default().fg(TEXT_PRIMARY)),
-            Span::styled("esc", Style::default().fg(ratatui::style::Color::Rgb(255, 100, 100)).add_modifier(Modifier::BOLD)),
-            Span::styled(" cancel", Style::default().fg(TEXT_PRIMARY)),
-        ])
-    ]).alignment(Alignment::Center);
+    let controls = Paragraph::new(vec![Line::from(vec![
+        Span::styled(
+            "enter",
+            Style::default()
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" play   ", Style::default().fg(TEXT_PRIMARY)),
+        Span::styled(
+            "esc",
+            Style::default()
+                .fg(ratatui::style::Color::Rgb(255, 100, 100))
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" cancel", Style::default().fg(TEXT_PRIMARY)),
+    ])])
+    .alignment(Alignment::Center);
 
     f.render_widget(controls, chunks[2]);
 }
 
 fn add_metadata_lines(details: &mut Vec<Line>, info: &serde_json::Map<String, serde_json::Value>) {
-    if let Some(rating) = info.get("rating").and_then(|v| {
-        match v {
-            serde_json::Value::String(s) => Some(s.clone()),
-            serde_json::Value::Number(n) => Some(n.to_string()),
-            _ => None,
-        }
+    if let Some(rating) = info.get("rating").and_then(|v| match v {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        _ => None,
     }) {
         details.push(Line::from(vec![
             Span::styled("rating   ", Style::default().fg(TEXT_SECONDARY)),
-            Span::styled(format!("{} / 10", rating), Style::default().fg(MATRIX_GREEN)),
+            Span::styled(
+                format!("{} / 10", rating),
+                Style::default().fg(MATRIX_GREEN),
+            ),
         ]));
     }
 
-    if let Some(runtime) = info.get("runtime").and_then(|v| {
-        match v {
-            serde_json::Value::String(s) => Some(s.clone()),
-            serde_json::Value::Number(n) => Some(n.to_string()),
-            _ => None,
-        }
+    if let Some(runtime) = info.get("runtime").and_then(|v| match v {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        _ => None,
     }) {
         details.push(Line::from(vec![
             Span::styled("runtime  ", Style::default().fg(TEXT_SECONDARY)),
-            Span::styled(format!("{} min", runtime), Style::default().fg(TEXT_PRIMARY)),
+            Span::styled(
+                format!("{} min", runtime),
+                Style::default().fg(TEXT_PRIMARY),
+            ),
         ]));
     }
 
@@ -505,7 +583,11 @@ fn add_metadata_lines(details: &mut Vec<Line>, info: &serde_json::Map<String, se
         ]));
     }
 
-    if let Some(cast) = info.get("cast").and_then(|v| v.as_str()).or_else(|| info.get("actors").and_then(|v| v.as_str())) {
+    if let Some(cast) = info
+        .get("cast")
+        .and_then(|v| v.as_str())
+        .or_else(|| info.get("actors").and_then(|v| v.as_str()))
+    {
         details.push(Line::from(vec![
             Span::styled("cast     ", Style::default().fg(TEXT_SECONDARY)),
             Span::styled(cast.to_string(), Style::default().fg(MATRIX_GREEN)),
@@ -514,10 +596,15 @@ fn add_metadata_lines(details: &mut Vec<Line>, info: &serde_json::Map<String, se
 
     details.push(Line::from(""));
 
-    if let Some(plot) = info.get("plot").and_then(|v| v.as_str()).or_else(|| info.get("description").and_then(|v| v.as_str())) {
-        details.push(Line::from(vec![
-            Span::styled(plot.to_string(), Style::default().fg(TEXT_SECONDARY)),
-        ]));
+    if let Some(plot) = info
+        .get("plot")
+        .and_then(|v| v.as_str())
+        .or_else(|| info.get("description").and_then(|v| v.as_str()))
+    {
+        details.push(Line::from(vec![Span::styled(
+            plot.to_string(),
+            Style::default().fg(TEXT_SECONDARY),
+        )]));
     }
 }
 
@@ -535,9 +622,12 @@ pub fn render_update_prompt(f: &mut Frame, app: &App, area: Rect) {
     let current_version = env!("CARGO_PKG_VERSION");
 
     let text = vec![
-        Line::from(vec![
-            Span::styled("A newer version of Matrix IPTV is available!", Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD)),
-        ]),
+        Line::from(vec![Span::styled(
+            "A newer version of Matrix IPTV is available!",
+            Style::default()
+                .fg(TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        )]),
         Line::from(""),
         Line::from(vec![
             Span::styled("  current  ", Style::default().fg(TEXT_SECONDARY)),
@@ -545,24 +635,44 @@ pub fn render_update_prompt(f: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(vec![
             Span::styled("  new      ", Style::default().fg(TEXT_SECONDARY)),
-            Span::styled(new_version, Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                new_version,
+                Style::default()
+                    .fg(MATRIX_GREEN)
+                    .add_modifier(Modifier::BOLD),
+            ),
         ]),
         Line::from(""),
-        Line::from(vec![
-            Span::styled("The update will be downloaded and installed automatically.", Style::default().fg(TEXT_SECONDARY)),
-        ]),
+        Line::from(vec![Span::styled(
+            "The update will be downloaded and installed automatically.",
+            Style::default().fg(TEXT_SECONDARY),
+        )]),
     ];
 
-    f.render_widget(Paragraph::new(text).alignment(Alignment::Center).wrap(Wrap { trim: true }), chunks[0]);
+    f.render_widget(
+        Paragraph::new(text)
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: true }),
+        chunks[0],
+    );
 
-    let controls = Paragraph::new(vec![
-        Line::from(vec![
-            Span::styled("enter/u", Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
-            Span::styled(" update   ", Style::default().fg(TEXT_PRIMARY)),
-            Span::styled("esc/l", Style::default().fg(ratatui::style::Color::Rgb(255, 100, 100)).add_modifier(Modifier::BOLD)),
-            Span::styled(" later", Style::default().fg(TEXT_PRIMARY)),
-        ])
-    ]).alignment(Alignment::Center);
+    let controls = Paragraph::new(vec![Line::from(vec![
+        Span::styled(
+            "enter/u",
+            Style::default()
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" update   ", Style::default().fg(TEXT_PRIMARY)),
+        Span::styled(
+            "esc/l",
+            Style::default()
+                .fg(ratatui::style::Color::Rgb(255, 100, 100))
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" later", Style::default().fg(TEXT_PRIMARY)),
+    ])])
+    .alignment(Alignment::Center);
 
     f.render_widget(controls, chunks[1]);
 }
@@ -571,7 +681,7 @@ pub fn render_cast_picker_popup(f: &mut Frame, app: &App, area: Rect) {
     let area = centered_rect(50, 50, area);
     f.render_widget(Clear, area);
     let inner = crate::ui::common::render_composite_block(f, area, Some("cast to device"));
-    
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .margin(1)
@@ -589,20 +699,29 @@ pub fn render_cast_picker_popup(f: &mut Frame, app: &App, area: Rect) {
     } else {
         "Select a Chromecast device:"
     };
-    
+
     let title = Paragraph::new(title_text)
         .alignment(Alignment::Center)
-        .style(Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD));
+        .style(
+            Style::default()
+                .fg(TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        );
     f.render_widget(title, chunks[0]);
 
     if app.cast_devices.is_empty() {
-        let empty_msg = if app.cast_discovering { "Please wait..." } else { "Press R to rescan or check your network" };
+        let empty_msg = if app.cast_discovering {
+            "Please wait..."
+        } else {
+            "Press R to rescan or check your network"
+        };
         let empty = Paragraph::new(empty_msg)
             .alignment(Alignment::Center)
             .style(Style::default().fg(TEXT_DIM));
         f.render_widget(empty, chunks[1]);
     } else {
-        let items: Vec<ListItem> = app.cast_devices
+        let items: Vec<ListItem> = app
+            .cast_devices
             .iter()
             .map(|device| {
                 let model_str = device.model.as_deref().unwrap_or("Chromecast");
@@ -616,21 +735,40 @@ pub fn render_cast_picker_popup(f: &mut Frame, app: &App, area: Rect) {
 
         let mut list_state = app.cast_device_list_state;
         let list = List::new(items)
-            .highlight_style(Style::default().bg(HIGHLIGHT_BG).fg(MATRIX_GREEN).add_modifier(Modifier::BOLD))
+            .highlight_style(
+                Style::default()
+                    .bg(HIGHLIGHT_BG)
+                    .fg(MATRIX_GREEN)
+                    .add_modifier(Modifier::BOLD),
+            )
             .highlight_symbol(" ▎");
         f.render_stateful_widget(list, chunks[1], &mut list_state);
     }
 
-    let controls = Paragraph::new(vec![
-        Line::from(vec![
-            Span::styled("enter", Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
-            Span::styled(" cast   ", Style::default().fg(TEXT_PRIMARY)),
-            Span::styled("r", Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)),
-            Span::styled(" rescan   ", Style::default().fg(TEXT_PRIMARY)),
-            Span::styled("esc", Style::default().fg(ratatui::style::Color::Rgb(255, 100, 100)).add_modifier(Modifier::BOLD)),
-            Span::styled(" cancel", Style::default().fg(TEXT_PRIMARY)),
-        ])
-    ]).alignment(Alignment::Center);
+    let controls = Paragraph::new(vec![Line::from(vec![
+        Span::styled(
+            "enter",
+            Style::default()
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" cast   ", Style::default().fg(TEXT_PRIMARY)),
+        Span::styled(
+            "r",
+            Style::default()
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" rescan   ", Style::default().fg(TEXT_PRIMARY)),
+        Span::styled(
+            "esc",
+            Style::default()
+                .fg(ratatui::style::Color::Rgb(255, 100, 100))
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" cancel", Style::default().fg(TEXT_PRIMARY)),
+    ])])
+    .alignment(Alignment::Center);
 
     f.render_widget(controls, chunks[2]);
 }

--- a/src/ui/series.rs
+++ b/src/ui/series.rs
@@ -1,3 +1,9 @@
+use crate::app::{App, Pane};
+use crate::parser::parse_stream;
+use crate::ui::colors::{
+    DARK_GREEN, HIGHLIGHT_BG, MATRIX_GREEN, SOFT_GREEN, TEXT_DIM, TEXT_PRIMARY,
+};
+use crate::ui::common::stylize_channel_name;
 use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
@@ -5,10 +11,6 @@ use ratatui::{
     widgets::{List, ListItem},
     Frame,
 };
-use crate::app::{App, Pane};
-use crate::ui::colors::{MATRIX_GREEN, SOFT_GREEN, DARK_GREEN, HIGHLIGHT_BG, TEXT_PRIMARY, TEXT_DIM};
-use crate::parser::parse_stream;
-use crate::ui::common::stylize_channel_name;
 
 pub fn render_series_view(f: &mut Frame, app: &mut App, area: Rect) {
     let is_active = true; // Overall view is active
@@ -30,12 +32,11 @@ pub fn render_series_view(f: &mut Frame, app: &mut App, area: Rect) {
                 ratatui::layout::Constraint::Percentage(60),
             ])
             .split(area);
-            
+
         render_series_streams_pane(f, app, chunks[0]);
         render_series_episodes_pane(f, app, chunks[1]);
     }
 }
-
 
 fn render_series_streams_pane(f: &mut Frame, app: &mut App, area: Rect) {
     let visible_height = area.height.saturating_sub(2) as usize;
@@ -43,18 +44,23 @@ fn render_series_streams_pane(f: &mut Frame, app: &mut App, area: Rect) {
     let selected = app.selected_series_stream_index;
 
     let half_window = visible_height / 2;
-    let start = if selected > half_window { selected - half_window } else { 0 };
+    let start = selected.saturating_sub(half_window);
     let end = (start + visible_height + half_window).min(total);
     let adjusted_start = if end == total && end > visible_height + half_window {
         end.saturating_sub(visible_height + half_window)
-    } else { start };
+    } else {
+        start
+    };
 
-    let items: Vec<ListItem> = app.series_streams.iter().enumerate()
+    let items: Vec<ListItem> = app
+        .series_streams
+        .iter()
+        .enumerate()
         .skip(adjusted_start)
         .take(end - adjusted_start)
         .map(|(_, s)| {
             let mut spans = vec![];
-            
+
             // O(1) metadata retrieval from pre-computed cache
             let (display_name, quality) = if let Some(ref parsed) = s.cached_parsed {
                 (parsed.display_name.clone(), parsed.quality)
@@ -68,35 +74,48 @@ fn render_series_streams_pane(f: &mut Frame, app: &mut App, area: Rect) {
             if let Some(mat) = re_year.find(&s.name) {
                 let year_clean = mat.as_str().replace('[', "(").replace(']', ")");
                 if !name.contains(&year_clean) {
-                    name.push_str(" ");
+                    name.push(' ');
                     name.push_str(&year_clean);
                 }
             }
 
             // Check if recently watched (progress indicator)
-            let is_watched = app.config.recently_watched.iter().any(|(id, _)| id == &s.stream_id.to_string());
-            let prefix = if is_watched { "✓ "} else { "" };
+            let is_watched = app
+                .config
+                .recently_watched
+                .iter()
+                .any(|(id, _)| id == &s.stream_id.to_string());
+            let prefix = if is_watched { "✓ " } else { "" };
             let prefixed_name = format!("{}{}", prefix, name);
 
             let (mut styled_name, _) = stylize_channel_name(
-                &prefixed_name, false, false, quality, None, None,
+                &prefixed_name,
+                false,
+                false,
+                quality,
+                None,
+                None,
                 Style::default().fg(TEXT_PRIMARY),
             );
-            
+
             // Colorize the checkmark if it's there
             if is_watched {
                 if let Some(first_span) = styled_name.first_mut() {
                     if first_span.content.starts_with("✓") {
-                        let check_span = ratatui::text::Span::styled("✓ ", Style::default().fg(crate::ui::colors::SOFT_GREEN));
-                        first_span.content = std::borrow::Cow::Owned(first_span.content[2..].to_string());
-                        
+                        let check_span = ratatui::text::Span::styled(
+                            "✓ ",
+                            Style::default().fg(crate::ui::colors::SOFT_GREEN),
+                        );
+                        first_span.content =
+                            std::borrow::Cow::Owned(first_span.content[2..].to_string());
+
                         let mut new_spans = vec![check_span];
                         new_spans.extend(styled_name);
                         styled_name = new_spans;
                     }
                 }
             }
-            
+
             spans.extend(styled_name);
 
             if let Some(rating_f) = s.rating {
@@ -111,19 +130,28 @@ fn render_series_streams_pane(f: &mut Frame, app: &mut App, area: Rect) {
             }
 
             ListItem::new(Line::from(spans))
-        }).collect();
+        })
+        .collect();
 
     let title = "series";
     let is_active = app.active_pane == Pane::Streams;
     let border_color = if is_active { SOFT_GREEN } else { DARK_GREEN };
-    let inner_area = crate::ui::common::render_matrix_box_active(f, area, &title, border_color, is_active);
+    let inner_area =
+        crate::ui::common::render_matrix_box_active(f, area, title, border_color, is_active);
 
     let list = List::new(items)
-        .highlight_style(Style::default().bg(HIGHLIGHT_BG).fg(MATRIX_GREEN).add_modifier(Modifier::BOLD))
+        .highlight_style(
+            Style::default()
+                .bg(HIGHLIGHT_BG)
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        )
         .highlight_symbol(" ▎");
 
-    let mut adjusted_state = app.series_stream_list_state.clone();
-    if adjusted_start > 0 { adjusted_state.select(Some(selected - adjusted_start)); }
+    let mut adjusted_state = app.series_stream_list_state;
+    if adjusted_start > 0 {
+        adjusted_state.select(Some(selected - adjusted_start));
+    }
     f.render_stateful_widget(list, inner_area, &mut adjusted_state);
 }
 
@@ -133,13 +161,18 @@ fn render_series_episodes_pane(f: &mut Frame, app: &mut App, area: Rect) {
     let selected = app.selected_series_episode_index;
 
     let half_window = visible_height / 2;
-    let start = if selected > half_window { selected - half_window } else { 0 };
+    let start = selected.saturating_sub(half_window);
     let end = (start + visible_height + half_window).min(total);
     let adjusted_start = if end == total && end > visible_height + half_window {
         end.saturating_sub(visible_height + half_window)
-    } else { start };
+    } else {
+        start
+    };
 
-    let items: Vec<ListItem> = app.series_episodes.iter().enumerate()
+    let items: Vec<ListItem> = app
+        .series_episodes
+        .iter()
+        .enumerate()
         .skip(adjusted_start)
         .take(end - adjusted_start)
         .map(|(_, ep)| {
@@ -147,24 +180,35 @@ fn render_series_episodes_pane(f: &mut Frame, app: &mut App, area: Rect) {
             let spans = vec![
                 ratatui::text::Span::styled(
                     format!("S{:02}E{:02}", ep.season, ep.episode_num),
-                    Style::default().fg(MATRIX_GREEN).add_modifier(Modifier::BOLD)
+                    Style::default()
+                        .fg(MATRIX_GREEN)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 ratatui::text::Span::styled(" · ", Style::default().fg(TEXT_DIM)),
                 ratatui::text::Span::styled(title.to_string(), Style::default().fg(TEXT_PRIMARY)),
             ];
             ListItem::new(Line::from(spans))
-        }).collect();
+        })
+        .collect();
 
     let title = "episodes";
     let is_active = app.active_pane == Pane::Episodes;
     let border_color = if is_active { SOFT_GREEN } else { DARK_GREEN };
-    let inner_area = crate::ui::common::render_matrix_box_active(f, area, &title, border_color, is_active);
+    let inner_area =
+        crate::ui::common::render_matrix_box_active(f, area, title, border_color, is_active);
 
     let list = List::new(items)
-        .highlight_style(Style::default().bg(HIGHLIGHT_BG).fg(MATRIX_GREEN).add_modifier(Modifier::BOLD))
+        .highlight_style(
+            Style::default()
+                .bg(HIGHLIGHT_BG)
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        )
         .highlight_symbol(" ▎");
 
-    let mut adjusted_state = app.series_episode_list_state.clone();
-    if adjusted_start > 0 { adjusted_state.select(Some(selected - adjusted_start)); }
+    let mut adjusted_state = app.series_episode_list_state;
+    if adjusted_start > 0 {
+        adjusted_state.select(Some(selected - adjusted_start));
+    }
     f.render_stateful_widget(list, inner_area, &mut adjusted_state);
 }

--- a/src/ui/sports.rs
+++ b/src/ui/sports.rs
@@ -1,3 +1,9 @@
+use crate::app::{App, Pane};
+use crate::sports::get_team_color;
+use crate::ui::colors::{
+    DARK_GREEN, HIGHLIGHT_BG, MATRIX_GREEN, SOFT_GREEN, TEXT_DIM, TEXT_PRIMARY, TEXT_SECONDARY,
+};
+use crate::ui::common::render_matrix_box;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -5,10 +11,6 @@ use ratatui::{
     widgets::{List, ListItem, Paragraph, Wrap},
     Frame,
 };
-use crate::app::{App, Pane};
-use crate::ui::colors::{MATRIX_GREEN, SOFT_GREEN, DARK_GREEN, HIGHLIGHT_BG, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_DIM};
-use crate::ui::common::render_matrix_box;
-use crate::sports::get_team_color;
 
 pub fn render_sports_view(f: &mut Frame, app: &mut App, area: Rect) {
     let chunks = Layout::default()
@@ -29,66 +31,98 @@ fn render_sports_categories_pane(f: &mut Frame, app: &mut App, area: Rect) {
     let is_active = app.active_pane == Pane::Categories;
     let border_color = if is_active { SOFT_GREEN } else { DARK_GREEN };
 
-    let items: Vec<ListItem> = app.sports_categories.iter().map(|cat| {
-        let display = cat.to_uppercase().replace("-", " ");
-        ListItem::new(Line::from(vec![
-            Span::styled(display, Style::default().fg(MATRIX_GREEN)),
-        ]))
-    }).collect();
+    let items: Vec<ListItem> = app
+        .sports_categories
+        .iter()
+        .map(|cat| {
+            let display = cat.to_uppercase().replace("-", " ");
+            ListItem::new(Line::from(vec![Span::styled(
+                display,
+                Style::default().fg(MATRIX_GREEN),
+            )]))
+        })
+        .collect();
 
-    let inner_area = crate::ui::common::render_matrix_box_active(f, area, "sports", border_color, is_active);
+    let inner_area =
+        crate::ui::common::render_matrix_box_active(f, area, "sports", border_color, is_active);
 
     let list = List::new(items)
-        .highlight_style(Style::default().bg(HIGHLIGHT_BG).fg(MATRIX_GREEN).add_modifier(Modifier::BOLD))
+        .highlight_style(
+            Style::default()
+                .bg(HIGHLIGHT_BG)
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        )
         .highlight_symbol(" ▎");
 
     f.render_stateful_widget(list, inner_area, &mut app.sports_category_list_state);
 }
 
 fn render_sports_matches_pane(f: &mut Frame, app: &mut App, area: Rect) {
-    let category = &app.sports_categories[app.selected_sports_category_index].to_uppercase().replace("-", " ");
+    let category = &app.sports_categories[app.selected_sports_category_index]
+        .to_uppercase()
+        .replace("-", " ");
     let title = format!("{} ({})", category.to_lowercase(), app.sports_matches.len());
     let is_active = app.active_pane == Pane::Streams;
     let border_color = if is_active { SOFT_GREEN } else { DARK_GREEN };
 
-    let items: Vec<ListItem> = app.sports_matches.iter().map(|m| {
-        let mut spans = Vec::new();
-        
-        let icon = match m.category.as_str() {
-            "football" => "",
-            "basketball" => "",
-            "baseball" => "",
-            "hockey" => "",
-            "ufc" | "mma" => "",
-            "f1" | "racing" => "",
-            "tennis" => "",
-            _ => "",
-        };
-        spans.push(Span::styled(icon, Style::default()));
+    let items: Vec<ListItem> = app
+        .sports_matches
+        .iter()
+        .map(|m| {
+            let mut spans = Vec::new();
 
-        if let Some(teams) = &m.teams {
-            if let Some(home) = &teams.home {
-                spans.push(Span::styled(&home.name, Style::default().fg(get_team_color(&home.name))));
-                spans.push(Span::styled(" vs ", Style::default().fg(TEXT_DIM)));
+            let icon = match m.category.as_str() {
+                "football" => "",
+                "basketball" => "",
+                "baseball" => "",
+                "hockey" => "",
+                "ufc" | "mma" => "",
+                "f1" | "racing" => "",
+                "tennis" => "",
+                _ => "",
+            };
+            spans.push(Span::styled(icon, Style::default()));
+
+            if let Some(teams) = &m.teams {
+                if let Some(home) = &teams.home {
+                    spans.push(Span::styled(
+                        &home.name,
+                        Style::default().fg(get_team_color(&home.name)),
+                    ));
+                    spans.push(Span::styled(" vs ", Style::default().fg(TEXT_DIM)));
+                }
+                if let Some(away) = &teams.away {
+                    spans.push(Span::styled(
+                        &away.name,
+                        Style::default().fg(get_team_color(&away.name)),
+                    ));
+                }
+            } else {
+                spans.push(Span::styled(&m.title, Style::default().fg(TEXT_PRIMARY)));
             }
-            if let Some(away) = &teams.away {
-                spans.push(Span::styled(&away.name, Style::default().fg(get_team_color(&away.name))));
+
+            if m.popular {
+                spans.push(Span::styled(
+                    " *",
+                    Style::default().fg(Color::Rgb(255, 100, 100)),
+                ));
             }
-        } else {
-            spans.push(Span::styled(&m.title, Style::default().fg(TEXT_PRIMARY)));
-        }
 
-        if m.popular {
-            spans.push(Span::styled(" *", Style::default().fg(Color::Rgb(255, 100, 100))));
-        }
+            ListItem::new(Line::from(spans))
+        })
+        .collect();
 
-        ListItem::new(Line::from(spans))
-    }).collect();
-
-    let inner_area = crate::ui::common::render_matrix_box_active(f, area, &title, border_color, is_active);
+    let inner_area =
+        crate::ui::common::render_matrix_box_active(f, area, &title, border_color, is_active);
 
     let list = List::new(items)
-        .highlight_style(Style::default().bg(HIGHLIGHT_BG).fg(MATRIX_GREEN).add_modifier(Modifier::BOLD))
+        .highlight_style(
+            Style::default()
+                .bg(HIGHLIGHT_BG)
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        )
         .highlight_symbol(" ▎");
 
     f.render_stateful_widget(list, inner_area, &mut app.sports_list_state);
@@ -101,9 +135,12 @@ fn render_sports_details_pane(f: &mut Frame, app: &mut App, area: Rect) {
     if let Some(m) = app.sports_matches.get(selected_idx) {
         let mut details = Vec::new();
 
-        details.push(Line::from(vec![
-            Span::styled(&m.title, Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD)),
-        ]));
+        details.push(Line::from(vec![Span::styled(
+            &m.title,
+            Style::default()
+                .fg(TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        )]));
         details.push(Line::from(""));
 
         let time_str = chrono::DateTime::from_timestamp(m.date / 1000, 0)
@@ -113,53 +150,77 @@ fn render_sports_details_pane(f: &mut Frame, app: &mut App, area: Rect) {
         details.push(Line::from(vec![
             Span::styled("status  ", Style::default().fg(TEXT_SECONDARY)),
             if m.popular {
-                Span::styled("live - trending", Style::default().fg(Color::Rgb(255, 100, 100)).add_modifier(Modifier::BOLD))
+                Span::styled(
+                    "live - trending",
+                    Style::default()
+                        .fg(Color::Rgb(255, 100, 100))
+                        .add_modifier(Modifier::BOLD),
+                )
             } else {
                 Span::styled("scheduled", Style::default().fg(TEXT_SECONDARY))
-            }
+            },
         ]));
         details.push(Line::from(vec![
             Span::styled("time    ", Style::default().fg(TEXT_SECONDARY)),
             Span::styled(time_str, Style::default().fg(MATRIX_GREEN)),
         ]));
-        
+
         details.push(Line::from(""));
 
         if let Some(teams) = &m.teams {
             if let Some(home) = &teams.home {
                 details.push(Line::from(vec![
                     Span::styled("home    ", Style::default().fg(TEXT_SECONDARY)),
-                    Span::styled(&home.name, Style::default().fg(get_team_color(&home.name)).add_modifier(Modifier::BOLD)),
+                    Span::styled(
+                        &home.name,
+                        Style::default()
+                            .fg(get_team_color(&home.name))
+                            .add_modifier(Modifier::BOLD),
+                    ),
                 ]));
             }
             if let Some(away) = &teams.away {
                 details.push(Line::from(vec![
                     Span::styled("away    ", Style::default().fg(TEXT_SECONDARY)),
-                    Span::styled(&away.name, Style::default().fg(get_team_color(&away.name)).add_modifier(Modifier::BOLD)),
+                    Span::styled(
+                        &away.name,
+                        Style::default()
+                            .fg(get_team_color(&away.name))
+                            .add_modifier(Modifier::BOLD),
+                    ),
                 ]));
             }
             details.push(Line::from(""));
         }
 
-        details.push(Line::from(vec![
-            Span::styled("channels", Style::default().fg(TEXT_SECONDARY)),
-        ]));
+        details.push(Line::from(vec![Span::styled(
+            "channels",
+            Style::default().fg(TEXT_SECONDARY),
+        )]));
 
         if app.sports_details_loading {
-            details.push(Line::from(vec![
-                Span::styled("  scanning...", Style::default().fg(TEXT_DIM)),
-            ]));
+            details.push(Line::from(vec![Span::styled(
+                "  scanning...",
+                Style::default().fg(TEXT_DIM),
+            )]));
         } else if app.current_sports_streams.is_empty() {
-             details.push(Line::from(vec![
-                Span::styled("  no channels found", Style::default().fg(TEXT_DIM)),
-            ]));
+            details.push(Line::from(vec![Span::styled(
+                "  no channels found",
+                Style::default().fg(TEXT_DIM),
+            )]));
         } else {
             for stream in &app.current_sports_streams {
                 let quality = if stream.hd { "HD" } else { "SD" };
                 details.push(Line::from(vec![
                     Span::styled("  > ", Style::default().fg(SOFT_GREEN)),
-                    Span::styled(format!("Ch {} ", stream.stream_no), Style::default().fg(TEXT_PRIMARY)),
-                    Span::styled(format!("({}) ", stream.language), Style::default().fg(TEXT_SECONDARY)),
+                    Span::styled(
+                        format!("Ch {} ", stream.stream_no),
+                        Style::default().fg(TEXT_PRIMARY),
+                    ),
+                    Span::styled(
+                        format!("({}) ", stream.language),
+                        Style::default().fg(TEXT_SECONDARY),
+                    ),
                     Span::styled(quality, Style::default().fg(MATRIX_GREEN)),
                 ]));
             }

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -1,31 +1,27 @@
+use crate::api::{Category, SeriesEpisode, Stream};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use crate::api::{Category, Stream, SeriesEpisode};
 use std::sync::Arc;
 
 pub fn calculate_max_category_width(categories: &[Arc<Category>], total_width: u16) -> u16 {
     if categories.is_empty() {
         return 25; // Minimum default width
     }
-    
+
     let max_content = categories
         .iter()
-        .map(|c| {
-            (c.category_name.len() as u16) + 5
-        })
+        .map(|c| (c.category_name.len() as u16) + 5)
         .max()
         .unwrap_or(25);
 
     let dynamic_max = (total_width * 40 / 100).max(45);
-    
-    max_content
-        .max(25) 
-        .min(dynamic_max) 
+
+    max_content.max(25).min(dynamic_max)
 }
 
 pub fn calculate_two_column_split(categories: &[Arc<Category>], total_width: u16) -> (u16, u16) {
     let cat_width = calculate_max_category_width(categories, total_width);
-    let min_stream_width = 60; 
-    
+    let min_stream_width = 60;
+
     if cat_width + min_stream_width > total_width {
         (total_width * 30 / 100, total_width * 70 / 100)
     } else {
@@ -40,22 +36,20 @@ pub fn calculate_three_column_split(
     total_width: u16,
 ) -> (u16, u16, u16) {
     let cat_width = calculate_max_category_width(categories, total_width);
-    
+
     let series_max_content = if series.is_empty() {
         35
     } else {
         series
             .iter()
-            .map(|s| {
-                (s.name.len() as u16) + 13
-            })
+            .map(|s| (s.name.len() as u16) + 13)
             .max()
             .unwrap_or(35)
     };
-    
+
     let series_dynamic_max = (total_width * 35 / 100).max(45);
     let series_width = series_max_content.max(35).min(series_dynamic_max);
-    
+
     let episode_max_content = if episodes.is_empty() {
         45
     } else {
@@ -71,11 +65,15 @@ pub fn calculate_three_column_split(
 
     let min_episode_width = 50;
     let episode_width = episode_max_content.max(min_episode_width);
-    
+
     let total_needed = cat_width + series_width + episode_width;
-    
+
     if total_needed > total_width {
-        (total_width * 25 / 100, total_width * 35 / 100, total_width * 40 / 100)
+        (
+            total_width * 25 / 100,
+            total_width * 35 / 100,
+            total_width * 40 / 100,
+        )
     } else {
         let remaining = total_width - cat_width - series_width;
         (cat_width, series_width, remaining.max(episode_width))
@@ -88,28 +86,30 @@ pub fn calculate_vod_three_column_split(
     total_width: u16,
 ) -> (u16, u16, u16) {
     let cat_width = calculate_max_category_width(categories, total_width);
-    
+
     let stream_max_content = if streams.is_empty() {
         35
     } else {
         streams
             .iter()
-            .map(|s| {
-                (s.name.len() as u16) + 13
-            })
+            .map(|s| (s.name.len() as u16) + 13)
             .max()
             .unwrap_or(35)
     };
-    
+
     let stream_dynamic_max = (total_width * 35 / 100).max(45);
     let stream_width = stream_max_content.max(35).min(stream_dynamic_max);
-    
-    let details_width = 50; 
-    
+
+    let details_width = 50;
+
     let total_needed = cat_width + stream_width + details_width;
-    
+
     if total_needed > total_width {
-        (total_width * 25 / 100, total_width * 35 / 100, total_width * 40 / 100)
+        (
+            total_width * 25 / 100,
+            total_width * 35 / 100,
+            total_width * 40 / 100,
+        )
     } else {
         let remaining = total_width - cat_width - stream_width;
         (cat_width, stream_width, remaining)

--- a/src/ui/vod.rs
+++ b/src/ui/vod.rs
@@ -1,3 +1,8 @@
+use crate::app::{App, Pane};
+use crate::ui::colors::{
+    DARK_GREEN, HIGHLIGHT_BG, MATRIX_GREEN, SOFT_GREEN, TEXT_DIM, TEXT_PRIMARY, TEXT_SECONDARY,
+};
+use crate::ui::common::stylize_channel_name;
 use ratatui::{
     layout::{Alignment, Rect},
     style::{Modifier, Style},
@@ -5,9 +10,6 @@ use ratatui::{
     widgets::{List, ListItem, Paragraph, Wrap},
     Frame,
 };
-use crate::app::{App, Pane};
-use crate::ui::colors::{MATRIX_GREEN, SOFT_GREEN, DARK_GREEN, HIGHLIGHT_BG, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_DIM};
-use crate::ui::common::stylize_channel_name;
 
 /// Strip provider-prefixed country/region codes from a title.
 /// e.g.  "EN| The Arborist"        → "The Arborist"
@@ -43,11 +45,11 @@ pub fn render_vod_view(f: &mut Frame, app: &mut App, area: Rect) {
     } else {
         // Streams stage: Master-Detail view (Streams | Details)
         let show_detail = area.width >= 80;
-        
+
         if show_detail {
             let detail_width = 40u16.min(area.width / 2);
             let streams_width = area.width.saturating_sub(detail_width);
-            
+
             let h_chunks = ratatui::layout::Layout::default()
                 .direction(ratatui::layout::Direction::Horizontal)
                 .constraints([
@@ -64,28 +66,32 @@ pub fn render_vod_view(f: &mut Frame, app: &mut App, area: Rect) {
     }
 }
 
-
 pub fn render_vod_streams_pane(f: &mut Frame, app: &mut App, area: Rect) {
     let visible_height = area.height.saturating_sub(2) as usize;
     let total = app.vod_streams.len();
     let selected = app.selected_vod_stream_index;
 
     let half_window = visible_height / 2;
-    let start = if selected > half_window { selected - half_window } else { 0 };
+    let start = selected.saturating_sub(half_window);
     let end = (start + visible_height + half_window).min(total);
     let adjusted_start = if end == total && end > visible_height + half_window {
         end.saturating_sub(visible_height + half_window)
-    } else { start };
+    } else {
+        start
+    };
 
     // Usable inner width = column width - 2 borders - 2 highlight symbol - 1 padding
     let inner_w = area.width.saturating_sub(5) as usize;
 
-    let items: Vec<ListItem> = app.vod_streams.iter().enumerate()
+    let items: Vec<ListItem> = app
+        .vod_streams
+        .iter()
+        .enumerate()
         .skip(adjusted_start)
         .take(end - adjusted_start)
         .map(|(_, s)| {
             let parsed = if let Some(ref cached) = s.cached_parsed {
-                 cached.as_ref().clone()
+                cached.as_ref().clone()
             } else {
                 crate::parser::parse_stream(&s.name, app.provider_timezone.as_deref())
             };
@@ -95,34 +101,51 @@ pub fn render_vod_streams_pane(f: &mut Frame, app: &mut App, area: Rect) {
             let name = parsed.display_name.clone();
 
             // Check if recently watched (progress indicator)
-            let is_watched = app.config.recently_watched.iter().any(|(id, _)| id == &s.stream_id.to_string());
-            let prefix = if is_watched { "✓ "} else { "" };
+            let is_watched = app
+                .config
+                .recently_watched
+                .iter()
+                .any(|(id, _)| id == &s.stream_id.to_string());
+            let prefix = if is_watched { "✓ " } else { "" };
             let prefixed_name = format!("{}{}", prefix, name);
 
             // Reserve space for year and rating: " (2024)" [7] + " [8.5]" [6] = 13 chars
             let has_year = parsed.year.is_some();
             let has_rating = s.rating.map(|r| r > 0.0).unwrap_or(false);
             let mut metadata_reserve = 0;
-            if has_year { metadata_reserve += 7; }
-            if has_rating { metadata_reserve += 6; }
-            
+            if has_year {
+                metadata_reserve += 7;
+            }
+            if has_rating {
+                metadata_reserve += 6;
+            }
+
             let max_name_len = inner_w.saturating_sub(metadata_reserve);
 
             // Hard-truncate title so it never overflows the column
             let display_name = truncate_to(&prefixed_name, max_name_len);
 
             let (mut styled_name, _) = stylize_channel_name(
-                &display_name, false, false, parsed.quality, None, None,
+                &display_name,
+                false,
+                false,
+                parsed.quality,
+                None,
+                None,
                 Style::default().fg(TEXT_PRIMARY),
             );
-            
+
             // Colorize the checkmark if it's there
             if is_watched {
                 if let Some(first_span) = styled_name.first_mut() {
                     if first_span.content.starts_with("✓") {
-                        let check_span = ratatui::text::Span::styled("✓ ", Style::default().fg(crate::ui::colors::SOFT_GREEN));
-                        first_span.content = std::borrow::Cow::Owned(first_span.content[2..].to_string());
-                        
+                        let check_span = ratatui::text::Span::styled(
+                            "✓ ",
+                            Style::default().fg(crate::ui::colors::SOFT_GREEN),
+                        );
+                        first_span.content =
+                            std::borrow::Cow::Owned(first_span.content[2..].to_string());
+
                         let mut new_spans = vec![check_span];
                         new_spans.extend(styled_name);
                         styled_name = new_spans;
@@ -153,20 +176,29 @@ pub fn render_vod_streams_pane(f: &mut Frame, app: &mut App, area: Rect) {
             }
 
             ListItem::new(Line::from(spans))
-        }).collect();
+        })
+        .collect();
 
     // Show total count in title — position indicator is less useful than total here
     let title = "movies";
     let is_active = app.active_pane == Pane::Streams;
     let border_color = if is_active { SOFT_GREEN } else { DARK_GREEN };
-    let inner_area = crate::ui::common::render_matrix_box_active(f, area, &title, border_color, is_active);
+    let inner_area =
+        crate::ui::common::render_matrix_box_active(f, area, title, border_color, is_active);
 
     let list = List::new(items)
-        .highlight_style(Style::default().bg(HIGHLIGHT_BG).fg(MATRIX_GREEN).add_modifier(Modifier::BOLD))
+        .highlight_style(
+            Style::default()
+                .bg(HIGHLIGHT_BG)
+                .fg(MATRIX_GREEN)
+                .add_modifier(Modifier::BOLD),
+        )
         .highlight_symbol(" ▎");
 
-    let mut adjusted_state = app.vod_stream_list_state.clone();
-    if adjusted_start > 0 { adjusted_state.select(Some(selected - adjusted_start)); }
+    let mut adjusted_state = app.vod_stream_list_state;
+    if adjusted_start > 0 {
+        adjusted_state.select(Some(selected - adjusted_start));
+    }
     f.render_stateful_widget(list, inner_area, &mut adjusted_state);
 }
 
@@ -176,13 +208,20 @@ pub fn render_vod_details_pane(f: &mut Frame, app: &mut App, area: Rect) {
 
     let mut details_text: Vec<Line> = Vec::new();
     let current_selection = app.vod_streams.get(app.selected_vod_stream_index);
-    
+
     if let Some(vod_info) = &app.current_vod_info {
         if let Some(info) = &vod_info.info {
             // ── Title ──────────────────────────────────────────────
-            let raw_title = info.get("name").and_then(|v| v.as_str()).map(|s| s.to_string())
+            let raw_title = info
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
                 .or_else(|| vod_info.movie_data.as_ref().and_then(|m| m.name.clone()))
-                .unwrap_or_else(|| current_selection.map(|s| s.name.clone()).unwrap_or_default());
+                .unwrap_or_else(|| {
+                    current_selection
+                        .map(|s| s.name.clone())
+                        .unwrap_or_default()
+                });
 
             let mut title = strip_provider_prefix(&raw_title).to_string();
 
@@ -204,23 +243,24 @@ pub fn render_vod_details_pane(f: &mut Frame, app: &mut App, area: Rect) {
             }
 
             if !title.is_empty() {
-                details_text.push(Line::from(vec![
-                    ratatui::text::Span::styled(
-                        truncate_to(&title, panel_w),
-                        Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD),
-                    ),
-                ]));
+                details_text.push(Line::from(vec![ratatui::text::Span::styled(
+                    truncate_to(&title, panel_w),
+                    Style::default()
+                        .fg(TEXT_PRIMARY)
+                        .add_modifier(Modifier::BOLD),
+                )]));
                 details_text.push(Line::from(""));
             }
 
             // ── Rating ─────────────────────────────────────────────
-            if let Some(rating_raw) = info.get("rating").and_then(|v| {
-                match v {
+            if let Some(rating_raw) = info
+                .get("rating")
+                .and_then(|v| match v {
                     serde_json::Value::String(s) if !s.is_empty() => Some(s.clone()),
                     serde_json::Value::Number(n) => Some(n.to_string()),
                     _ => None,
-                }
-            }).or_else(|| current_selection.and_then(|s| s.rating.map(|r| r.to_string()))) 
+                })
+                .or_else(|| current_selection.and_then(|s| s.rating.map(|r| r.to_string())))
             {
                 let rating_val: f64 = rating_raw.parse().unwrap_or(0.0);
                 if rating_val > 0.0 {
@@ -229,7 +269,10 @@ pub fn render_vod_details_pane(f: &mut Frame, app: &mut App, area: Rect) {
                     let empty = 5usize.saturating_sub(filled);
                     let stars = format!("{}{}", "*".repeat(filled), "-".repeat(empty));
                     details_text.push(Line::from(vec![
-                        ratatui::text::Span::styled("rating  ", Style::default().fg(TEXT_SECONDARY)),
+                        ratatui::text::Span::styled(
+                            "rating  ",
+                            Style::default().fg(TEXT_SECONDARY),
+                        ),
                         ratatui::text::Span::styled(
                             format!("{}/10  {}", rating_raw, stars),
                             Style::default().fg(rating_color),
@@ -239,17 +282,21 @@ pub fn render_vod_details_pane(f: &mut Frame, app: &mut App, area: Rect) {
             }
 
             // ── Runtime ────────────────────────────────────────────
-            if let Some(runtime) = info.get("runtime").and_then(|v| {
-                match v {
-                    serde_json::Value::String(s) if !s.is_empty() => Some(s.clone()),
-                    serde_json::Value::Number(n) => Some(n.to_string()),
-                    _ => None,
-                }
+            if let Some(runtime) = info.get("runtime").and_then(|v| match v {
+                serde_json::Value::String(s) if !s.is_empty() => Some(s.clone()),
+                serde_json::Value::Number(n) => Some(n.to_string()),
+                _ => None,
             }) {
                 if !runtime.is_empty() && runtime != "0" {
                     details_text.push(Line::from(vec![
-                        ratatui::text::Span::styled("runtime ", Style::default().fg(TEXT_SECONDARY)),
-                        ratatui::text::Span::styled(format!("{} min", runtime), Style::default().fg(TEXT_PRIMARY)),
+                        ratatui::text::Span::styled(
+                            "runtime ",
+                            Style::default().fg(TEXT_SECONDARY),
+                        ),
+                        ratatui::text::Span::styled(
+                            format!("{} min", runtime),
+                            Style::default().fg(TEXT_PRIMARY),
+                        ),
                     ]));
                 }
             }
@@ -258,7 +305,10 @@ pub fn render_vod_details_pane(f: &mut Frame, app: &mut App, area: Rect) {
             if let Some(releasedate) = info.get("releasedate").and_then(|v| v.as_str()) {
                 if !releasedate.is_empty() {
                     details_text.push(Line::from(vec![
-                        ratatui::text::Span::styled("released ", Style::default().fg(TEXT_SECONDARY)),
+                        ratatui::text::Span::styled(
+                            "released ",
+                            Style::default().fg(TEXT_SECONDARY),
+                        ),
                         ratatui::text::Span::styled(releasedate, Style::default().fg(TEXT_PRIMARY)),
                     ]));
                 }
@@ -268,34 +318,45 @@ pub fn render_vod_details_pane(f: &mut Frame, app: &mut App, area: Rect) {
             if let Some(genre) = info.get("genre").and_then(|v| v.as_str()) {
                 if !genre.is_empty() {
                     details_text.push(Line::from(vec![
-                        ratatui::text::Span::styled("genre   ", Style::default().fg(TEXT_SECONDARY)),
+                        ratatui::text::Span::styled(
+                            "genre   ",
+                            Style::default().fg(TEXT_SECONDARY),
+                        ),
                         ratatui::text::Span::styled(genre, Style::default().fg(TEXT_PRIMARY)),
                     ]));
                 }
             }
 
             // ── Plot ───────────────────────────────────────────────
-            if let Some(plot) = info.get("plot").and_then(|v| v.as_str())
+            if let Some(plot) = info
+                .get("plot")
+                .and_then(|v| v.as_str())
                 .or_else(|| info.get("description").and_then(|v| v.as_str()))
             {
                 if !plot.is_empty() {
                     details_text.push(Line::from(""));
-                    details_text.push(Line::from(
-                        ratatui::text::Span::styled(plot, Style::default().fg(TEXT_SECONDARY)),
-                    ));
+                    details_text.push(Line::from(ratatui::text::Span::styled(
+                        plot,
+                        Style::default().fg(TEXT_SECONDARY),
+                    )));
                     details_text.push(Line::from(""));
                 }
             }
 
             // ── Cast ───────────────────────────────────────────────
-            if let Some(cast) = info.get("cast").and_then(|v| v.as_str())
+            if let Some(cast) = info
+                .get("cast")
+                .and_then(|v| v.as_str())
                 .or_else(|| info.get("actors").and_then(|v| v.as_str()))
             {
                 if !cast.is_empty() {
                     let cast_display = truncate_to(cast, panel_w.saturating_sub(5));
                     details_text.push(Line::from(vec![
                         ratatui::text::Span::styled("cast ", Style::default().fg(TEXT_SECONDARY)),
-                        ratatui::text::Span::styled(cast_display, Style::default().fg(TEXT_PRIMARY)),
+                        ratatui::text::Span::styled(
+                            cast_display,
+                            Style::default().fg(TEXT_PRIMARY),
+                        ),
                     ]));
                 }
             }
@@ -309,13 +370,13 @@ pub fn render_vod_details_pane(f: &mut Frame, app: &mut App, area: Rect) {
             (p.display_name, p.quality)
         };
 
-        details_text.push(Line::from(vec![
-            ratatui::text::Span::styled(
-                truncate_to(&display_name, panel_w),
-                Style::default().fg(TEXT_PRIMARY).add_modifier(Modifier::BOLD),
-            ),
-        ]));
-        
+        details_text.push(Line::from(vec![ratatui::text::Span::styled(
+            truncate_to(&display_name, panel_w),
+            Style::default()
+                .fg(TEXT_PRIMARY)
+                .add_modifier(Modifier::BOLD),
+        )]));
+
         if let Some(rating_f) = stream.rating {
             if rating_f > 0.0 {
                 let rating_str = format!("{:.1}", rating_f);

--- a/src/wasm_client.rs
+++ b/src/wasm_client.rs
@@ -6,7 +6,6 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 
-
 #[wasm_bindgen]
 extern "C" {
     fn playStream(url: &str);
@@ -80,7 +79,7 @@ impl WasmClient {
                             let base_url = acc.base_url.clone();
                             let username = acc.username.clone();
                             let password = acc.password.clone();
-                            
+
                             // Auto-inject localhost:8081 for POC testing if not already present
                             let proxy_url = if !base_url.contains("localhost") {
                                 format!("http://localhost:8081/{}", base_url)
@@ -88,14 +87,17 @@ impl WasmClient {
                                 base_url
                             };
 
-                            web_sys::console::log_1(&format!("[Wasm] Authenticating via proxy: {}", proxy_url).into());
+                            web_sys::console::log_1(
+                                &format!("[Wasm] Authenticating via proxy: {}", proxy_url).into(),
+                            );
 
-                            let client = crate::api::XtreamClient::new(proxy_url, username, password);
+                            let client =
+                                crate::api::XtreamClient::new(proxy_url, username, password);
                             app.current_client = Some(client.clone());
                             app.state_loading = true;
 
                             let app_rc = self.app.clone();
-                            
+
                             // Spawn async login
                             wasm_bindgen_futures::spawn_local(async move {
                                 let result = client.authenticate().await;
@@ -103,40 +105,61 @@ impl WasmClient {
                                     let mut app = app_rc.borrow_mut();
                                     app.state_loading = false;
                                 }
-                                
+
                                 match result {
                                     Ok((true, user_info, server_info)) => {
-                                        web_sys::console::log_1(&"[Wasm] Login Successful. Fetching categories...".into());
+                                        web_sys::console::log_1(
+                                            &"[Wasm] Login Successful. Fetching categories..."
+                                                .into(),
+                                        );
                                         let mut app = app_rc.borrow_mut();
-                                        app.cached_user_timezone = server_info.as_ref()
+                                        app.cached_user_timezone = server_info
+                                            .as_ref()
                                             .and_then(|i| i.timezone.clone())
                                             .unwrap_or_else(|| "UTC".into());
-                                        
+
                                         let client_clone = client.clone();
                                         let app_rc_inner = app_rc.clone();
-                                        
+
                                         // Fetch categories
                                         wasm_bindgen_futures::spawn_local(async move {
-                                             let cats_res = client_clone.get_live_categories().await;
-                                             let mut app = app_rc_inner.borrow_mut();
-                                             match cats_res {
-                                                 Ok(cats) => {
-                                                     web_sys::console::log_1(&format!("[Wasm] Loaded {} categories.", cats.len()).into());
-                                                     app.categories = cats.clone();
-                                                     app.all_categories = cats;
-                                                     app.current_screen = CurrentScreen::Categories;
-                                                 }
-                                                 Err(e) => {
-                                                     web_sys::console::error_1(&format!("[Wasm] Failed to load categories: {}", e).into());
-                                                 }
-                                             }
+                                            let cats_res = client_clone.get_live_categories().await;
+                                            let mut app = app_rc_inner.borrow_mut();
+                                            match cats_res {
+                                                Ok(cats) => {
+                                                    web_sys::console::log_1(
+                                                        &format!(
+                                                            "[Wasm] Loaded {} categories.",
+                                                            cats.len()
+                                                        )
+                                                        .into(),
+                                                    );
+                                                    app.categories = cats.clone();
+                                                    app.all_categories = cats;
+                                                    app.current_screen = CurrentScreen::Categories;
+                                                }
+                                                Err(e) => {
+                                                    web_sys::console::error_1(
+                                                        &format!(
+                                                            "[Wasm] Failed to load categories: {}",
+                                                            e
+                                                        )
+                                                        .into(),
+                                                    );
+                                                }
+                                            }
                                         });
-                                    },
+                                    }
                                     Ok((false, _, _)) => {
-                                         web_sys::console::error_1(&"[Wasm] Login Failed: Invalid Credentials".into());
-                                    },
+                                        web_sys::console::error_1(
+                                            &"[Wasm] Login Failed: Invalid Credentials".into(),
+                                        );
+                                    }
                                     Err(e) => {
-                                        web_sys::console::error_1(&format!("[Wasm] Network Error during login: {}", e).into());
+                                        web_sys::console::error_1(
+                                            &format!("[Wasm] Network Error during login: {}", e)
+                                                .into(),
+                                        );
                                     }
                                 }
                             });
@@ -266,18 +289,17 @@ impl WasmClient {
                     "Tab" => {
                         if app.current_screen == CurrentScreen::Categories {
                             app.current_screen = CurrentScreen::VodCategories;
-                             // Fetch VOD categories async?
-                             if let Some(client) = &app.current_client {
-                                 let client = client.clone();
-                                 let app_rc = self.app.clone();
-                                 wasm_bindgen_futures::spawn_local(async move {
-                                     if let Ok(cats) = client.get_vod_categories().await {
-                                         let mut app = app_rc.borrow_mut();
-                                         app.vod_categories = cats;
-                                     }
-                                 });
-                             }
-
+                            // Fetch VOD categories async?
+                            if let Some(client) = &app.current_client {
+                                let client = client.clone();
+                                let app_rc = self.app.clone();
+                                wasm_bindgen_futures::spawn_local(async move {
+                                    if let Ok(cats) = client.get_vod_categories().await {
+                                        let mut app = app_rc.borrow_mut();
+                                        app.vod_categories = cats;
+                                    }
+                                });
+                            }
                         } else if app.current_screen == CurrentScreen::VodCategories {
                             app.current_screen = CurrentScreen::Categories;
                         }
@@ -304,35 +326,46 @@ impl WasmClient {
                                 if let Some(cat) = app.get_selected_category() {
                                     let id = cat.category_id.clone();
                                     if let Some(client) = &app.current_client {
-                                         let client = client.clone();
-                                         let app_rc = self.app.clone();
-                                         // Show loading?
-                                         wasm_bindgen_futures::spawn_local(async move {
-                                             if let Ok(streams) = client.get_live_streams(&id).await {
-                                                 let mut app = app_rc.borrow_mut();
-                                                 app.streams = streams.clone();
-                                                 app.all_streams = streams;
-                                                 app.current_screen = CurrentScreen::Streams; 
-                                             }
-                                         });
+                                        let client = client.clone();
+                                        let app_rc = self.app.clone();
+                                        // Show loading?
+                                        wasm_bindgen_futures::spawn_local(async move {
+                                            if let Ok(streams) = client.get_live_streams(&id).await
+                                            {
+                                                let mut app = app_rc.borrow_mut();
+                                                app.streams = streams.clone();
+                                                app.all_streams = streams;
+                                                app.current_screen = CurrentScreen::Streams;
+                                            }
+                                        });
                                     }
                                 }
                             }
                             CurrentScreen::Streams => {
                                 if let Some(stream) = app.get_selected_stream() {
-                                     let stream_id = stream.stream_id.to_string_value().unwrap_or_default();
-                                     let ext = stream.container_extension.clone().unwrap_or_else(|| "m3u8".to_string());
-                                     
-                                     if let Some(client) = &app.current_client {
-                                         let url = client.get_stream_url(&stream_id, &ext);
-                                         web_sys::console::log_1(&format!("[Wasm] Playing Stream: {} (URL: {})", stream.name, url).into());
-                                         
-                                         // Trigger JS playback
-                                         playStream(&url);
-                                     }
+                                    let stream_id =
+                                        stream.stream_id.to_string_value().unwrap_or_default();
+                                    let ext = stream
+                                        .container_extension
+                                        .clone()
+                                        .unwrap_or_else(|| "m3u8".to_string());
+
+                                    if let Some(client) = &app.current_client {
+                                        let url = client.get_stream_url(&stream_id, &ext);
+                                        web_sys::console::log_1(
+                                            &format!(
+                                                "[Wasm] Playing Stream: {} (URL: {})",
+                                                stream.name, url
+                                            )
+                                            .into(),
+                                        );
+
+                                        // Trigger JS playback
+                                        playStream(&url);
+                                    }
                                 }
                             }
-                             _ => {}
+                            _ => {}
                         }
                     }
                     _ => {}

--- a/tests/caching_test.rs
+++ b/tests/caching_test.rs
@@ -28,7 +28,6 @@ fn test_stream_caching_logic() {
     // Note: Caching now happens lazily on first render, not in update_search
     // Call pre_cache_parsed to verify the caching logic still works
     App::pre_cache_parsed(&mut app.streams, None);
-    
     let cached_stream = &app.streams[0];
     
     // The Critical Verify: Is the cache populated after explicit caching?

--- a/tests/caching_test.rs
+++ b/tests/caching_test.rs
@@ -1,6 +1,6 @@
 use matrix_iptv_lib::api::Stream;
-use matrix_iptv_lib::flex_id::FlexId;
 use matrix_iptv_lib::app::{App, CurrentScreen, Pane};
+use matrix_iptv_lib::flex_id::FlexId;
 use std::sync::Arc;
 
 #[test]
@@ -10,7 +10,7 @@ fn test_stream_caching_logic() {
     // Ensure we are in a state where update_search processes streams
     app.current_screen = CurrentScreen::Categories;
     app.active_pane = Pane::Streams;
-    
+
     // Add a test stream
     let stream = Stream {
         name: "Test Stream US".to_string(),
@@ -18,21 +18,24 @@ fn test_stream_caching_logic() {
         ..Default::default()
     };
     app.all_streams = vec![Arc::new(stream)];
-    
+
     // Trigger the caching logic
     app.update_search();
-    
+
     // Verify results
     assert!(!app.streams.is_empty(), "Streams list should be populated");
-    
+
     // Note: Caching now happens lazily on first render, not in update_search
     // Call pre_cache_parsed to verify the caching logic still works
     App::pre_cache_parsed(&mut app.streams, None);
     let cached_stream = &app.streams[0];
-    
+
     // The Critical Verify: Is the cache populated after explicit caching?
-    assert!(cached_stream.cached_parsed.is_some(), "cached_parsed should be Some after pre_cache_parsed");
-    
+    assert!(
+        cached_stream.cached_parsed.is_some(),
+        "cached_parsed should be Some after pre_cache_parsed"
+    );
+
     // Verify the parsed content matches expectation
     let parsed = cached_stream.cached_parsed.as_ref().unwrap();
     assert_eq!(parsed.original_name, "Test Stream US");

--- a/tests/frontend_screens_test.rs
+++ b/tests/frontend_screens_test.rs
@@ -174,12 +174,20 @@ fn test_all_screens_render_empty_state() {
 #[test]
 fn test_footer_hints_match_vod_and_series_stream_hotkeys() {
     let mut app = App::new();
+    app.current_screen = CurrentScreen::Categories;
+    app.active_pane = Pane::Categories;
+    app.categories = generate_categories(2);
+    let live_text = render_frame_text(&mut app);
+    assert!(!live_text.contains("PgDn"));
+
+    let mut app = App::new();
     app.current_screen = CurrentScreen::VodStreams;
     app.active_pane = Pane::Streams;
     app.streams = generate_streams(2);
     let vod_text = render_frame_text(&mut app);
     assert!(vod_text.contains("g top"));
     assert!(vod_text.contains("G bottom"));
+    assert!(!vod_text.contains("PgDn"));
     assert!(!vod_text.contains("g add group"));
     assert!(!vod_text.contains("v fav"));
     assert!(!vod_text.contains("i info"));
@@ -192,6 +200,7 @@ fn test_footer_hints_match_vod_and_series_stream_hotkeys() {
     assert!(series_text.contains("enter episodes"));
     assert!(series_text.contains("Home top"));
     assert!(series_text.contains("End bottom"));
+    assert!(!series_text.contains("PgDn"));
     assert!(!series_text.contains("g add group"));
     assert!(!series_text.contains("v fav"));
     assert!(!series_text.contains("i info"));
@@ -268,6 +277,8 @@ fn test_help_popup_does_not_advertise_stale_hotkeys() {
     let text = render_frame_text(&mut app);
     assert!(!text.contains("g/G         jump to top / bottom"));
     assert!(!text.contains("toggle filter active/all"));
+    assert!(!text.contains("PgDn/PgUp"));
+    assert!(!text.contains("ctrl+d/u"));
     assert!(text.contains("/ or f"));
     assert!(text.contains("category grid or live add-to-group"));
 }

--- a/tests/frontend_screens_test.rs
+++ b/tests/frontend_screens_test.rs
@@ -1,9 +1,9 @@
-use matrix_iptv_lib::app::{App, CurrentScreen, Pane};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use matrix_iptv_lib::api::{Category, SeriesEpisode, Stream};
+use matrix_iptv_lib::app::{App, CurrentScreen, Pane};
 use matrix_iptv_lib::flex_id::FlexId;
 use matrix_iptv_lib::handlers::input::handle_key_event;
 use matrix_iptv_lib::player::Player;
-use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
 use std::sync::Arc;
@@ -223,7 +223,10 @@ async fn test_runtime_navigation_matches_stream_footer_hints() {
     assert_eq!(app.selected_vod_stream_index, 0, "VOD g should jump to top");
 
     press_runtime_key(&mut app, KeyCode::Char('G')).await;
-    assert_eq!(app.selected_vod_stream_index, 2, "VOD G should jump to bottom");
+    assert_eq!(
+        app.selected_vod_stream_index, 2,
+        "VOD G should jump to bottom"
+    );
 
     let mut app = App::new();
     app.current_screen = CurrentScreen::SeriesCategories;
@@ -348,7 +351,11 @@ fn test_search_filtering_live_tv() {
     // Empty search → all streams
     app.search_state.query.clear();
     app.update_search();
-    assert_eq!(app.streams.len(), 5, "Empty search should return all streams");
+    assert_eq!(
+        app.streams.len(),
+        5,
+        "Empty search should return all streams"
+    );
 
     // Exact substring search
     app.search_state.query = "espn".to_string();
@@ -392,12 +399,23 @@ fn test_search_filtering_vod() {
 
     app.search_state.query = "matrix".to_string();
     app.update_search();
-    assert_eq!(app.vod_streams.len(), 1, "VOD search for 'matrix' should return 1");
-    assert!(app.vod_streams[0].cached_parsed.is_some(), "VOD stream should have cached parse");
+    assert_eq!(
+        app.vod_streams.len(),
+        1,
+        "VOD search for 'matrix' should return 1"
+    );
+    assert!(
+        app.vod_streams[0].cached_parsed.is_some(),
+        "VOD stream should have cached parse"
+    );
 
     app.search_state.query.clear();
     app.update_search();
-    assert_eq!(app.vod_streams.len(), 3, "Clearing search should restore all VOD streams");
+    assert_eq!(
+        app.vod_streams.len(),
+        3,
+        "Clearing search should restore all VOD streams"
+    );
 }
 
 // ─── Test 6: Search Filtering Correctness (Series) ────────────────────────────
@@ -415,11 +433,19 @@ fn test_search_filtering_series() {
 
     app.search_state.query = "wire".to_string();
     app.update_search();
-    assert_eq!(app.series_streams.len(), 1, "Series search for 'wire' should return 1");
+    assert_eq!(
+        app.series_streams.len(),
+        1,
+        "Series search for 'wire' should return 1"
+    );
 
     app.search_state.query.clear();
     app.update_search();
-    assert_eq!(app.series_streams.len(), 3, "Clearing search should restore all series");
+    assert_eq!(
+        app.series_streams.len(),
+        3,
+        "Clearing search should restore all series"
+    );
 }
 
 // ─── Test 7: Navigation Boundary Checks ────────────────────────────────────────
@@ -511,23 +537,20 @@ fn test_global_search_rendering() {
     let mut app = App::new();
 
     // Populate all content types into global pools
-    app.global_all_streams = vec![
-        make_stream(1, "ESPN HD"),
-        make_stream(2, "CNN"),
-    ];
-    app.global_all_vod_streams = vec![
-        make_vod_stream(10, "The Matrix (1999)"),
-    ];
-    app.global_all_series_streams = vec![
-        make_series_stream(20, "Breaking Bad"),
-    ];
+    app.global_all_streams = vec![make_stream(1, "ESPN HD"), make_stream(2, "CNN")];
+    app.global_all_vod_streams = vec![make_vod_stream(10, "The Matrix (1999)")];
+    app.global_all_series_streams = vec![make_series_stream(20, "Breaking Bad")];
 
     app.current_screen = CurrentScreen::GlobalSearch;
 
     // Empty search → no results
     app.search_state.query.clear();
     app.update_search();
-    assert_eq!(app.global_search_results.len(), 0, "Empty global search should show no results");
+    assert_eq!(
+        app.global_search_results.len(),
+        0,
+        "Empty global search should show no results"
+    );
     render_frame(&mut app);
 
     // Search across all types
@@ -539,7 +562,10 @@ fn test_global_search_rendering() {
     );
     // Verify caching
     for s in &app.global_search_results {
-        assert!(s.cached_parsed.is_some(), "Global search results should have cached_parsed");
+        assert!(
+            s.cached_parsed.is_some(),
+            "Global search results should have cached_parsed"
+        );
     }
     render_frame(&mut app);
 }
@@ -651,10 +677,7 @@ fn test_cross_pane_search() {
         make_category("1", "US Sports"),
         make_category("2", "UK News"),
     ];
-    app.global_all_streams = vec![
-        make_stream(1, "ESPN HD"),
-        make_stream(2, "BBC World"),
-    ];
+    app.global_all_streams = vec![make_stream(1, "ESPN HD"), make_stream(2, "BBC World")];
     app.current_screen = CurrentScreen::Categories;
     app.active_pane = Pane::Categories;
 

--- a/tests/frontend_screens_test.rs
+++ b/tests/frontend_screens_test.rs
@@ -51,6 +51,9 @@ fn make_category(id: &str, name: &str) -> Arc<Category> {
 
 /// Render one frame of the UI — panics on crash
 fn render_frame(app: &mut App) {
+    app.show_matrix_rain = false;
+    app.transition_last_screen = Some(app.current_screen.clone());
+    app.transition_effect = None;
     let backend = TestBackend::new(120, 40);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
@@ -58,6 +61,29 @@ fn render_frame(app: &mut App) {
             matrix_iptv_lib::ui::ui(f, app);
         })
         .unwrap();
+}
+
+fn render_frame_text(app: &mut App) -> String {
+    app.show_matrix_rain = false;
+    app.transition_last_screen = Some(app.current_screen.clone());
+    app.transition_effect = None;
+    let backend = TestBackend::new(140, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            matrix_iptv_lib::ui::ui(f, app);
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer();
+    let mut text = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            text.push_str(buffer[(x, y)].symbol());
+        }
+        text.push('\n');
+    }
+    text
 }
 
 /// Generate N streams with unique names for strong8k-scale testing
@@ -115,6 +141,43 @@ fn test_all_screens_render_empty_state() {
         render_frame(&mut app);
         // If we get here without panic, the screen rendered OK
     }
+}
+
+#[test]
+fn test_footer_hints_match_vod_and_series_stream_hotkeys() {
+    let mut app = App::new();
+    app.current_screen = CurrentScreen::VodStreams;
+    app.active_pane = Pane::Streams;
+    app.streams = generate_streams(2);
+    let vod_text = render_frame_text(&mut app);
+    assert!(vod_text.contains("g top"));
+    assert!(vod_text.contains("G bottom"));
+    assert!(!vod_text.contains("g add group"));
+    assert!(!vod_text.contains("v fav"));
+    assert!(!vod_text.contains("i info"));
+
+    let mut app = App::new();
+    app.current_screen = CurrentScreen::SeriesStreams;
+    app.active_pane = Pane::Streams;
+    app.series_streams = vec![make_series_stream(1, "US | Example Show")];
+    let series_text = render_frame_text(&mut app);
+    assert!(series_text.contains("enter episodes"));
+    assert!(series_text.contains("Home top"));
+    assert!(series_text.contains("End bottom"));
+    assert!(!series_text.contains("g add group"));
+    assert!(!series_text.contains("v fav"));
+    assert!(!series_text.contains("i info"));
+}
+
+#[test]
+fn test_help_popup_does_not_advertise_stale_hotkeys() {
+    let mut app = App::new();
+    app.show_help = true;
+    let text = render_frame_text(&mut app);
+    assert!(!text.contains("g/G         jump to top / bottom"));
+    assert!(!text.contains("toggle filter active/all"));
+    assert!(text.contains("/ or f"));
+    assert!(text.contains("category grid or live add-to-group"));
 }
 
 // ─── Test 2: Large Stream List (2000 items — strong8k scale) ───────────────────
@@ -368,7 +431,7 @@ fn test_global_search_rendering() {
     app.search_state.query = "the".to_string();
     app.update_search();
     assert!(
-        app.global_search_results.len() >= 1,
+        !app.global_search_results.is_empty(),
         "Global search for 'the' should match at least The Matrix"
     );
     // Verify caching
@@ -499,7 +562,7 @@ fn test_cross_pane_search() {
     // Categories should be filtered
     // Streams should also be searched cross-pane
     assert!(
-        app.streams.len() >= 1,
+        !app.streams.is_empty(),
         "Cross-pane search should find ESPN in streams"
     );
 }

--- a/tests/frontend_screens_test.rs
+++ b/tests/frontend_screens_test.rs
@@ -1,6 +1,9 @@
-use matrix_iptv_lib::api::{Category, Stream};
-use matrix_iptv_lib::flex_id::FlexId;
 use matrix_iptv_lib::app::{App, CurrentScreen, Pane};
+use matrix_iptv_lib::api::{Category, SeriesEpisode, Stream};
+use matrix_iptv_lib::flex_id::FlexId;
+use matrix_iptv_lib::handlers::input::handle_key_event;
+use matrix_iptv_lib::player::Player;
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
 use std::sync::Arc;
@@ -39,6 +42,18 @@ fn make_series_stream(id: u64, name: &str) -> Arc<Stream> {
     })
 }
 
+fn make_episode(id: i64, title: &str) -> SeriesEpisode {
+    SeriesEpisode {
+        id: Some(FlexId::Number(id)),
+        episode_num: id as i32,
+        title: Some(title.to_string()),
+        container_extension: Some("mp4".to_string()),
+        info: None,
+        season: 1,
+        direct_source: String::new(),
+    }
+}
+
 fn make_category(id: &str, name: &str) -> Arc<Category> {
     Arc::new(Category {
         category_id: id.to_string(),
@@ -47,6 +62,19 @@ fn make_category(id: &str, name: &str) -> Arc<Category> {
         parent_id: FlexId::Number(0),
         ..Default::default()
     })
+}
+
+async fn press_runtime_key(app: &mut App, code: KeyCode) {
+    let (tx, _rx) = tokio::sync::mpsc::channel(1);
+    let player = Player::new();
+    let key = KeyEvent {
+        code,
+        modifiers: KeyModifiers::NONE,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    };
+
+    handle_key_event(app, key, &tx, &player).await.unwrap();
 }
 
 /// Render one frame of the UI — panics on crash
@@ -167,6 +195,70 @@ fn test_footer_hints_match_vod_and_series_stream_hotkeys() {
     assert!(!series_text.contains("g add group"));
     assert!(!series_text.contains("v fav"));
     assert!(!series_text.contains("i info"));
+}
+
+#[tokio::test]
+async fn test_runtime_navigation_matches_stream_footer_hints() {
+    let mut app = App::new();
+    app.current_screen = CurrentScreen::VodStreams;
+    app.active_pane = Pane::Streams;
+    app.vod_streams = vec![
+        make_vod_stream(1, "Movie 1"),
+        make_vod_stream(2, "Movie 2"),
+        make_vod_stream(3, "Movie 3"),
+    ];
+    app.selected_vod_stream_index = 1;
+    app.vod_stream_list_state.select(Some(1));
+
+    press_runtime_key(&mut app, KeyCode::Char('g')).await;
+    assert_eq!(app.selected_vod_stream_index, 0, "VOD g should jump to top");
+
+    press_runtime_key(&mut app, KeyCode::Char('G')).await;
+    assert_eq!(app.selected_vod_stream_index, 2, "VOD G should jump to bottom");
+
+    let mut app = App::new();
+    app.current_screen = CurrentScreen::SeriesCategories;
+    app.series_categories = generate_categories(3);
+    app.selected_series_category_index = 0;
+    app.series_category_list_state.select(Some(0));
+
+    press_runtime_key(&mut app, KeyCode::Char('G')).await;
+    assert_eq!(
+        app.selected_series_category_index, 2,
+        "Series category G should jump to bottom"
+    );
+
+    let mut app = App::new();
+    app.current_screen = CurrentScreen::SeriesStreams;
+    app.active_pane = Pane::Streams;
+    app.series_streams = vec![
+        make_series_stream(1, "Show 1"),
+        make_series_stream(2, "Show 2"),
+        make_series_stream(3, "Show 3"),
+    ];
+    app.selected_series_stream_index = 1;
+    app.series_stream_list_state.select(Some(1));
+
+    press_runtime_key(&mut app, KeyCode::Home).await;
+    assert_eq!(app.selected_series_stream_index, 0);
+
+    press_runtime_key(&mut app, KeyCode::End).await;
+    assert_eq!(app.selected_series_stream_index, 2);
+
+    app.active_pane = Pane::Episodes;
+    app.series_episodes = vec![
+        make_episode(1, "Episode 1"),
+        make_episode(2, "Episode 2"),
+        make_episode(3, "Episode 3"),
+    ];
+    app.selected_series_episode_index = 1;
+    app.series_episode_list_state.select(Some(1));
+
+    press_runtime_key(&mut app, KeyCode::Home).await;
+    assert_eq!(app.selected_series_episode_index, 0);
+
+    press_runtime_key(&mut app, KeyCode::End).await;
+    assert_eq!(app.selected_series_episode_index, 2);
 }
 
 #[test]

--- a/tests/playlist_verification.rs
+++ b/tests/playlist_verification.rs
@@ -1,5 +1,5 @@
-use matrix_iptv_lib::app::{App, CurrentScreen, Pane};
 use matrix_iptv_lib::api::Category;
+use matrix_iptv_lib::app::{App, CurrentScreen, Pane};
 use matrix_iptv_lib::flex_id::FlexId;
 use std::sync::Arc;
 
@@ -7,86 +7,116 @@ use std::sync::Arc;
 fn test_navigation_sync_live_tv() {
     let mut app = App::new();
     app.all_categories = vec![
-        Arc::new(Category { category_id: "1".to_string(), category_name: "Action".to_string(), search_name: "action".to_string(), parent_id: FlexId::Number(0), ..Default::default() }),
-        Arc::new(Category { category_id: "2".to_string(), category_name: "Drama".to_string(), search_name: "drama".to_string(), parent_id: FlexId::Number(0), ..Default::default() }),
+        Arc::new(Category {
+            category_id: "1".to_string(),
+            category_name: "Action".to_string(),
+            search_name: "action".to_string(),
+            parent_id: FlexId::Number(0),
+            ..Default::default()
+        }),
+        Arc::new(Category {
+            category_id: "2".to_string(),
+            category_name: "Drama".to_string(),
+            search_name: "drama".to_string(),
+            parent_id: FlexId::Number(0),
+            ..Default::default()
+        }),
     ];
-    
+
     // Enter screen
     app.current_screen = CurrentScreen::Categories;
     app.active_pane = Pane::Categories;
     app.update_search();
     assert_eq!(app.categories.len(), 2);
-    
+
     // Search
     app.search_state.query = "Action".to_string();
     app.update_search();
     assert_eq!(app.categories.len(), 1);
-    
+
     // Back to Selection
     app.current_screen = CurrentScreen::ContentTypeSelection;
-    
+
     // Re-enter (Simulate the fix in main.rs)
     app.current_screen = CurrentScreen::Categories;
     app.active_pane = Pane::Categories;
     app.search_state.query.clear();
     app.search_mode = false;
     app.update_search(); // Added by fix
-    
-    assert_eq!(app.categories.len(), 2, "Live TV categories should be restored");
+
+    assert_eq!(
+        app.categories.len(),
+        2,
+        "Live TV categories should be restored"
+    );
 }
 
 #[test]
 fn test_navigation_sync_vod() {
     let mut app = App::new();
-    app.all_vod_categories = vec![
-        Arc::new(Category { category_id: "10".to_string(), category_name: "Movie1".to_string(), parent_id: FlexId::Number(0), ..Default::default() }),
-    ];
-    
+    app.all_vod_categories = vec![Arc::new(Category {
+        category_id: "10".to_string(),
+        category_name: "Movie1".to_string(),
+        parent_id: FlexId::Number(0),
+        ..Default::default()
+    })];
+
     app.current_screen = CurrentScreen::VodCategories;
     app.active_pane = Pane::Categories;
     app.update_search();
     assert_eq!(app.vod_categories.len(), 1);
-    
+
     app.search_state.query = "NoMatch".to_string();
     app.update_search();
     assert_eq!(app.vod_categories.len(), 0);
-    
+
     app.current_screen = CurrentScreen::ContentTypeSelection;
-    
+
     // Re-enter
     app.current_screen = CurrentScreen::VodCategories;
     app.active_pane = Pane::Categories;
     app.search_state.query.clear();
     app.search_mode = false;
     app.update_search();
-    
-    assert_eq!(app.vod_categories.len(), 1, "VOD categories should be restored");
+
+    assert_eq!(
+        app.vod_categories.len(),
+        1,
+        "VOD categories should be restored"
+    );
 }
 
 #[test]
 fn test_navigation_sync_series() {
     let mut app = App::new();
-    app.all_series_categories = vec![
-        Arc::new(Category { category_id: "20".to_string(), category_name: "Series1".to_string(), parent_id: FlexId::Number(0), ..Default::default() }),
-    ];
-    
+    app.all_series_categories = vec![Arc::new(Category {
+        category_id: "20".to_string(),
+        category_name: "Series1".to_string(),
+        parent_id: FlexId::Number(0),
+        ..Default::default()
+    })];
+
     app.current_screen = CurrentScreen::SeriesCategories;
     app.active_pane = Pane::Categories;
     app.update_search();
     assert_eq!(app.series_categories.len(), 1);
-    
+
     app.search_state.query = "Search".to_string();
     app.update_search();
     assert_eq!(app.series_categories.len(), 0);
-    
+
     app.current_screen = CurrentScreen::ContentTypeSelection;
-    
+
     // Re-enter
     app.current_screen = CurrentScreen::SeriesCategories;
     app.active_pane = Pane::Categories;
     app.search_state.query.clear();
     app.search_mode = false;
     app.update_search();
-    
-    assert_eq!(app.series_categories.len(), 1, "Series categories should be restored");
+
+    assert_eq!(
+        app.series_categories.len(),
+        1,
+        "Series categories should be restored"
+    );
 }

--- a/tests/test_geo_filter.rs
+++ b/tests/test_geo_filter.rs
@@ -1,7 +1,6 @@
 use matrix_iptv_lib::api::XtreamClient;
 use matrix_iptv_lib::config::{AppConfig, ProcessingMode};
 use matrix_iptv_lib::parser;
-use tokio;
 
 /// Comprehensive geo-filter verification test.
 /// Connects to the real provider, fetches Live/VOD/Series categories,
@@ -15,7 +14,7 @@ fn test_merica_filter_all_content_types() {
         let config = AppConfig::load().expect("Failed to load config.json");
         let account = config.accounts.first().expect("No accounts found");
         let is_merica = config.processing_modes.contains(&ProcessingMode::Merica);
-        
+
         println!("Account: {}", account.name);
         println!("'Merica mode active: {}", is_merica);
         println!("Processing modes: {:?}", config.processing_modes);
@@ -35,26 +34,35 @@ fn test_merica_filter_all_content_types() {
         match client.get_live_categories().await {
             Ok(cats) => {
                 println!("Total live categories from provider: {}", cats.len());
-                
-                let american: Vec<_> = cats.iter().filter(|c| parser::is_american_live(&c.category_name)).collect();
-                let foreign: Vec<_> = cats.iter().filter(|c| !parser::is_american_live(&c.category_name)).collect();
-                
+
+                let american: Vec<_> = cats
+                    .iter()
+                    .filter(|c| parser::is_american_live(&c.category_name))
+                    .collect();
+                let foreign: Vec<_> = cats
+                    .iter()
+                    .filter(|c| !parser::is_american_live(&c.category_name))
+                    .collect();
+
                 println!("American (pass filter): {} categories", american.len());
                 println!("Foreign  (blocked):     {} categories", foreign.len());
-                
+
                 // Show a sample of what gets blocked
                 println!("\n--- Sample BLOCKED live categories (first 20) ---");
                 for cat in foreign.iter().take(20) {
                     println!("  BLOCKED: {}", cat.category_name);
                 }
-                
+
                 // Show what passes
                 println!("\n--- Sample PASSED live categories (first 20) ---");
                 for cat in american.iter().take(20) {
                     println!("  PASSED:  {}", cat.category_name);
                 }
-                
-                assert!(american.len() > 0, "Must have at least some American live categories");
+
+                assert!(
+                    !american.is_empty(),
+                    "Must have at least some American live categories"
+                );
             }
             Err(e) => println!("SKIP live categories (error: {})", e),
         }
@@ -66,35 +74,48 @@ fn test_merica_filter_all_content_types() {
         match client.get_vod_categories().await {
             Ok(cats) => {
                 println!("Total VOD categories from provider: {}", cats.len());
-                
-                let english: Vec<_> = cats.iter().filter(|c| parser::is_english_vod(&c.category_name)).collect();
-                let foreign: Vec<_> = cats.iter().filter(|c| !parser::is_english_vod(&c.category_name)).collect();
-                
+
+                let english: Vec<_> = cats
+                    .iter()
+                    .filter(|c| parser::is_english_vod(&c.category_name))
+                    .collect();
+                let foreign: Vec<_> = cats
+                    .iter()
+                    .filter(|c| !parser::is_english_vod(&c.category_name))
+                    .collect();
+
                 println!("English (pass filter): {} categories", english.len());
                 println!("Foreign (blocked):     {} categories", foreign.len());
-                
+
                 // Show blocked
                 println!("\n--- Sample BLOCKED VOD categories (first 30) ---");
                 for cat in foreign.iter().take(30) {
                     println!("  BLOCKED: {}", cat.category_name);
                 }
-                
+
                 // Show passed
                 println!("\n--- Sample PASSED VOD categories (first 30) ---");
                 for cat in english.iter().take(30) {
                     println!("  PASSED:  {}", cat.category_name);
                 }
-                
+
                 // Specifically verify ALB, MT, TR are blocked
-                let alb_leak: Vec<_> = english.iter()
+                let alb_leak: Vec<_> = english
+                    .iter()
                     .filter(|c| {
                         let upper = c.category_name.to_uppercase();
-                        upper.starts_with("ALB") || upper.starts_with("MT ") || upper.starts_with("TR ")
-                            || upper.contains("| ALB") || upper.contains("| MT") || upper.contains("| TR")
-                            || upper.contains("|ALB") || upper.contains("|MT") || upper.contains("|TR")
+                        upper.starts_with("ALB")
+                            || upper.starts_with("MT ")
+                            || upper.starts_with("TR ")
+                            || upper.contains("| ALB")
+                            || upper.contains("| MT")
+                            || upper.contains("| TR")
+                            || upper.contains("|ALB")
+                            || upper.contains("|MT")
+                            || upper.contains("|TR")
                     })
                     .collect();
-                
+
                 if !alb_leak.is_empty() {
                     println!("\n!!! LEAKS DETECTED (ALB/MT/TR still passing) !!!");
                     for cat in &alb_leak {
@@ -103,8 +124,11 @@ fn test_merica_filter_all_content_types() {
                 } else {
                     println!("\n✓ No ALB/MT/TR leaks detected in VOD categories");
                 }
-                
-                assert!(english.len() > 0, "Must have at least some English VOD categories");
+
+                assert!(
+                    !english.is_empty(),
+                    "Must have at least some English VOD categories"
+                );
             }
             Err(e) => println!("SKIP VOD categories (error: {})", e),
         }
@@ -116,26 +140,35 @@ fn test_merica_filter_all_content_types() {
         match client.get_series_categories().await {
             Ok(cats) => {
                 println!("Total series categories from provider: {}", cats.len());
-                
-                let english: Vec<_> = cats.iter().filter(|c| parser::is_english_vod(&c.category_name)).collect();
-                let foreign: Vec<_> = cats.iter().filter(|c| !parser::is_english_vod(&c.category_name)).collect();
-                
+
+                let english: Vec<_> = cats
+                    .iter()
+                    .filter(|c| parser::is_english_vod(&c.category_name))
+                    .collect();
+                let foreign: Vec<_> = cats
+                    .iter()
+                    .filter(|c| !parser::is_english_vod(&c.category_name))
+                    .collect();
+
                 println!("English (pass filter): {} categories", english.len());
                 println!("Foreign (blocked):     {} categories", foreign.len());
-                
+
                 // Show blocked
                 println!("\n--- Sample BLOCKED series categories (first 30) ---");
                 for cat in foreign.iter().take(30) {
                     println!("  BLOCKED: {}", cat.category_name);
                 }
-                
+
                 // Show passed
                 println!("\n--- Sample PASSED series categories (first 30) ---");
                 for cat in english.iter().take(30) {
                     println!("  PASSED:  {}", cat.category_name);
                 }
-                
-                assert!(english.len() > 0, "Must have at least some English series categories");
+
+                assert!(
+                    !english.is_empty(),
+                    "Must have at least some English series categories"
+                );
             }
             Err(e) => println!("SKIP series categories (error: {})", e),
         }

--- a/tests/test_user_playlist.rs
+++ b/tests/test_user_playlist.rs
@@ -1,19 +1,21 @@
 use matrix_iptv_lib::api::XtreamClient;
 use matrix_iptv_lib::config::{AppConfig, ProcessingMode};
 use matrix_iptv_lib::preprocessing::preprocess_streams;
-use tokio;
 use std::collections::HashSet;
 
 #[test]
 fn test_user_real_playlist_msnbc() {
     let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
-    
+
     rt.block_on(async {
         // 1. Load the REAL user config
         let config = AppConfig::load().expect("Failed to load config.json");
-        
+
         // 2. Get the active account
-        let account = config.accounts.first().expect("No accounts found in config");
+        let account = config
+            .accounts
+            .first()
+            .expect("No accounts found in config");
         println!("Testing with Account: {}", account.name);
         println!("URL: {}", account.base_url);
 
@@ -29,20 +31,29 @@ fn test_user_real_playlist_msnbc() {
         match client.get_live_streams("ALL", None).await {
             Ok(mut streams) => {
                 println!("Downloaded {} raw streams.", streams.len());
-                assert!(streams.len() > 0, "Provider returned 0 streams!");
+                assert!(!streams.is_empty(), "Provider returned 0 streams!");
 
                 // 5. Apply 'Merica Mode Filtering
                 let favorites = HashSet::new();
                 let modes = vec![ProcessingMode::Merica];
-                
+
                 preprocess_streams(&mut streams, &favorites, &modes, true, &account.name, None);
-                
-                println!("Filtered down to {} streams using 'Merica mode.", streams.len());
+
+                println!(
+                    "Filtered down to {} streams using 'Merica mode.",
+                    streams.len()
+                );
 
                 // 6. Verify Content
-                let msnbc_count = streams.iter().filter(|s| s.search_name.contains("msnbc")).count();
-                let arab_count = streams.iter().filter(|s| s.search_name.contains("arab")).count();
-                
+                let msnbc_count = streams
+                    .iter()
+                    .filter(|s| s.search_name.contains("msnbc"))
+                    .count();
+                let arab_count = streams
+                    .iter()
+                    .filter(|s| s.search_name.contains("arab"))
+                    .count();
+
                 println!("Found {} MSNBC channels.", msnbc_count);
                 println!("Found {} ARAB channels.", arab_count);
 
@@ -55,10 +66,13 @@ fn test_user_real_playlist_msnbc() {
                 }
 
                 // 7. Assertions
-                assert!(msnbc_count > 0, "Real Playlist MUST contain MSNBC after filtering");
+                assert!(
+                    msnbc_count > 0,
+                    "Real Playlist MUST contain MSNBC after filtering"
+                );
                 // assert!(arab_count == 0, "Real Playlist MUST NOT contain ARAB content after filtering");
                 // Temporarily allow small leakage if it's false positives, but for now just print them.
-                
+
                 if let Some(msnbc) = streams.iter().find(|s| s.search_name.contains("msnbc")) {
                     println!("Sample MSNBC Name: '{}'", msnbc.name);
                 }

--- a/tests/verify_msnbc.rs
+++ b/tests/verify_msnbc.rs
@@ -1,8 +1,8 @@
-use std::collections::HashSet;
 use matrix_iptv_lib::api::Stream;
-use matrix_iptv_lib::flex_id::FlexId;
 use matrix_iptv_lib::config::ProcessingMode;
+use matrix_iptv_lib::flex_id::FlexId;
 use matrix_iptv_lib::preprocessing::preprocess_streams;
+use std::collections::HashSet;
 
 #[test]
 fn test_merica_mode_msnbc_verification() {
@@ -37,7 +37,7 @@ fn test_merica_mode_msnbc_verification() {
 
     let favorites = HashSet::new();
     let modes = vec![ProcessingMode::Merica];
-    
+
     // 2. Execution: Run the preprocessing logic
     // Note: The signature is (streams, favorites, modes, is_live, account_name, channel_tx)
     preprocess_streams(&mut streams, &favorites, &modes, true, "TestAccount", None);
@@ -47,26 +47,45 @@ fn test_merica_mode_msnbc_verification() {
     println!("Survived Streams: {:?}", names);
 
     // Assertions
-    assert!(names.iter().any(|n| n.contains("MSNBC")), "MSNBC should survive");
+    assert!(
+        names.iter().any(|n| n.contains("MSNBC")),
+        "MSNBC should survive"
+    );
     // Check clean name (preprocessing removes "US |")
-    assert!(names.iter().any(|n| n == "MSNBC HEVC"), "US | prefix should be cleaned");
-    
-    assert!(!names.iter().any(|n| n.contains("ARABE")), "ARABE-SPORTS should be removed");
-    assert!(!names.iter().any(|n| n.contains("BBC ONE")), "UK Content should be removed");
-    
+    assert!(
+        names.iter().any(|n| n == "MSNBC HEVC"),
+        "US | prefix should be cleaned"
+    );
+
+    assert!(
+        !names.iter().any(|n| n.contains("ARABE")),
+        "ARABE-SPORTS should be removed"
+    );
+    assert!(
+        !names.iter().any(|n| n.contains("BBC ONE")),
+        "UK Content should be removed"
+    );
+
     // 4. Search Verification (Simulating app.rs logic)
     // preprocessing populates search_name!
     let query = "msnbc";
-    let search_results: Vec<&Stream> = streams.iter()
+    let search_results: Vec<&Stream> = streams
+        .iter()
         .filter(|s| s.search_name.contains(query))
         .collect();
-    
-    assert!(!search_results.is_empty(), "Search for 'msnbc' should return results");
+
+    assert!(
+        !search_results.is_empty(),
+        "Search for 'msnbc' should return results"
+    );
     // Should pass finding "MSNBC HEVC" (cleaned) and "MSNBC" (original id 5)
     // Note: clean_american_name replaces name.
     // Stream 1 becomes "MSNBC HEVC". search_name "msnbc hevc".
     // Stream 5 becomes "MSNBC". search_name "msnbc".
-    
-    println!("Search Results: {:?}", search_results.iter().map(|s| &s.name).collect::<Vec<_>>());
+
+    println!(
+        "Search Results: {:?}",
+        search_results.iter().map(|s| &s.name).collect::<Vec<_>>()
+    );
     assert_eq!(search_results.len(), 2, "Should find both MSNBC channels");
 }


### PR DESCRIPTION
## What changed

- Keeps American live event/package categories visible in 'Merica mode, including NBA Package, NBA League Pass, PPV, and 24/7 provider categories.
- Preserves category names like `NBA Package` and `PPV Events` while still typing PPV content correctly.
- Removes the provider-specific Strong/Trex NBA denylist so real American sports packages are not filtered out.
- Updates footer/help hotkey guidance so VOD, series, live, group management, home, and help screens do not advertise stale shortcuts.
- Adds focused screen regression coverage for the corrected shortcut hints.
- Clears small warning-level issues in touched files so cloud review has less noise.

## Why

The Trex playlist uses provider category names such as NBA Package and PPV/24-7 buckets as real American content. The previous filtering path could treat those labels as generic package markers or provider noise, which made 'Merica mode too aggressive for American playlists.

This PR targets `develop` specifically because the repository cloud PR review workflow is configured for PRs into `develop`. PR #10 remains the `main`-targeted branch for the same feature line.

## Validation

- `cargo test --lib`
- `cargo test --test frontend_screens_test`
- `cargo test --tests --no-run`
- `cargo clippy --all-targets` exits 0; broad historical clippy warnings remain on `develop`, while low-risk warnings in touched files were cleaned where practical.
- `git diff --check origin/develop...HEAD`

## Live Trex evidence

Local Trex E2E evidence and screenshots were captured under `O:\matrix-iptv-merica-pr\target\trex-e2e` during the main-branch verification pass across live, movies, and series. Credentials were not written to tracked files.