### PR TITLE
[codex] Make self-updates transactional and recoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@ Legacy package name still works:
 npm install -g @officebeats/matrix-iptv-cli
 ```
 
+### **Updating**
+
+Matrix IPTV checks for new GitHub releases after startup without blocking the app.
+When an update is available, press `u` in the prompt to install it, `l` to be
+reminded later, or `s` to skip that version.
+
+You can also update directly from the terminal:
+
+```bash
+matrix-iptv update
+```
+
+The updater downloads the release asset for your platform, verifies size,
+checksum, and `--version`, installs through a temporary file, and restores the
+previous binary if the new one fails verification.
+
 ### **Maintainer Release Command**
 
 For repo releases, use the built-in release automation:

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,14 +1,19 @@
 #!/usr/bin/env node
 
-const { spawn } = require("child_process");
-const path = require("path");
-const os = require("os");
+const { spawn, spawnSync } = require("child_process");
+const crypto = require("crypto");
 const fs = require("fs");
-const https = require("https");
+const os = require("os");
+const path = require("path");
+const axios = require("axios");
 
-const binaryName =
-  os.platform() === "win32" ? "matrix-iptv.exe" : "matrix-iptv";
+const repo = "officebeats/matrix-iptv";
+const userAgent = "matrix-iptv-updater";
+const updateExitCode = 42;
+const minBinarySize = 1024 * 100;
+const binaryName = os.platform() === "win32" ? "matrix-iptv.exe" : "matrix-iptv";
 const binaryPath = path.join(__dirname, binaryName);
+const packageVersion = require("../package.json").version;
 
 const platformMap = {
   win32: "windows.exe",
@@ -16,196 +21,365 @@ const platformMap = {
   darwin: "macos",
 };
 
-const axios = require("axios");
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
-async function download(url, dest) {
-  const writer = fs.createWriteStream(dest);
-  
+function compareVersions(a, b) {
+  const parse = (value) =>
+    String(value || "")
+      .replace(/^v/i, "")
+      .split(".")
+      .map((part) => Number.parseInt(part, 10) || 0);
+  const left = parse(a);
+  const right = parse(b);
+  const length = Math.max(left.length, right.length);
+
+  for (let i = 0; i < length; i += 1) {
+    const diff = (left[i] || 0) - (right[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+function parseVersion(output) {
+  const match = String(output || "").match(/(\d+\.\d+\.\d+)/);
+  return match ? match[1] : null;
+}
+
+function getBinaryVersion(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+
+  const result = spawnSync(filePath, ["--version"], {
+    encoding: "utf8",
+    timeout: 10000,
+    windowsHide: true,
+    env: {
+      ...process.env,
+      MATRIX_IPTV_WRAPPER: "1",
+      MATRIX_IPTV_SKIP_UPDATE: "1",
+    },
+  });
+
+  if (result.error) {
+    throw new Error(`Unable to run ${path.basename(filePath)} --version: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    const message = (result.stderr || result.stdout || "").trim();
+    throw new Error(`Version check failed for ${path.basename(filePath)}${message ? `: ${message}` : ""}`);
+  }
+
+  return parseVersion(`${result.stdout}\n${result.stderr}`);
+}
+
+function currentInstalledVersion() {
   try {
-    const response = await axios({
-      method: 'get',
-      url: url,
-      responseType: 'stream',
-      headers: {
-        'Cache-Control': 'no-cache',
-        'User-Agent': 'matrix-iptv-updater'
-      }
-    });
-
-    response.data.pipe(writer);
-
-    return new Promise((resolve, reject) => {
-      writer.on('finish', resolve);
-      writer.on('error', (err) => {
-        fs.unlink(dest, () => {});
-        reject(err);
-      });
-    });
+    return getBinaryVersion(binaryPath);
   } catch (err) {
-    fs.unlink(dest, () => {});
-    if (err.response && err.response.status === 404) {
-      throw new Error(`Asset not found (404). This usually means the GitHub release exists but the binary hasn't been uploaded yet.`);
-    }
-    throw err;
+    console.log(`[!] Existing binary version check failed: ${err.message}`);
+    return null;
   }
 }
 
-async function performUpdate() {
+async function fetchRelease(targetVersion) {
+  const tag = targetVersion ? `v${String(targetVersion).replace(/^v/i, "")}` : null;
+  const url = tag
+    ? `https://api.github.com/repos/${repo}/releases/tags/${tag}`
+    : `https://api.github.com/repos/${repo}/releases/latest`;
+
+  const response = await axios.get(url, {
+    timeout: 15000,
+    headers: {
+      Accept: "application/vnd.github+json",
+      "Cache-Control": "no-cache",
+      "User-Agent": userAgent,
+    },
+  });
+
+  return response.data;
+}
+
+function selectAsset(release) {
   const platform = platformMap[os.platform()];
   if (!platform) {
     throw new Error(`Unsupported platform for auto-update: ${os.platform()}`);
   }
-  const releaseUrl = `https://github.com/officebeats/matrix-iptv/releases/latest/download/matrix-iptv-${platform}`;
 
-  console.log(`\n[*] Initiating Phase 4: System Update...`);
-  console.log(`[*] Downloading: ${releaseUrl}`);
+  const expectedName = `matrix-iptv-${platform}`;
+  const asset = (release.assets || []).find((item) => item.name === expectedName);
+  if (!asset) {
+    throw new Error(`Release ${release.tag_name} does not include ${expectedName}`);
+  }
+  return asset;
+}
 
-  const tempPath = binaryPath + ".tmp";
+async function downloadAsset(asset, destination) {
+  const response = await axios({
+    method: "get",
+    url: asset.browser_download_url,
+    responseType: "stream",
+    timeout: 60000,
+    headers: {
+      "Cache-Control": "no-cache",
+      "User-Agent": userAgent,
+    },
+  });
 
-  // Record old binary size for loop detection
-  let oldSize = 0;
+  await new Promise((resolve, reject) => {
+    const writer = fs.createWriteStream(destination, { flags: "wx" });
+    response.data.pipe(writer);
+    writer.on("finish", () => writer.close(resolve));
+    writer.on("error", (err) => {
+      fs.rm(destination, { force: true }, () => {});
+      reject(err);
+    });
+  });
+}
+
+function sha256(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function makeExecutable(filePath) {
+  if (os.platform() !== "win32") {
+    fs.chmodSync(filePath, 0o755);
+  }
+
+  if (os.platform() === "darwin") {
+    spawnSync("xattr", ["-d", "com.apple.quarantine", filePath], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+  }
+}
+
+function verifyDownloadedBinary(filePath, asset, expectedVersion) {
+  const stat = fs.statSync(filePath);
+  if (stat.size < minBinarySize) {
+    throw new Error(`Downloaded file is too small (${stat.size} bytes).`);
+  }
+
+  if (asset.size && stat.size !== asset.size) {
+    throw new Error(`Downloaded file size mismatch: expected ${asset.size}, got ${stat.size}.`);
+  }
+
+  if (asset.digest && asset.digest.startsWith("sha256:")) {
+    const expectedDigest = asset.digest.slice("sha256:".length).toLowerCase();
+    const actualDigest = sha256(filePath);
+    if (actualDigest !== expectedDigest) {
+      throw new Error("Downloaded binary checksum did not match the GitHub release asset digest.");
+    }
+  } else {
+    console.log("[!] GitHub did not provide a release asset digest; continuing with size and version checks.");
+  }
+
+  makeExecutable(filePath);
+
+  const actualVersion = getBinaryVersion(filePath);
+  if (actualVersion !== expectedVersion) {
+    throw new Error(`Downloaded binary reports version ${actualVersion || "unknown"}, expected ${expectedVersion}.`);
+  }
+}
+
+async function retry(label, action, attempts = 15) {
+  let lastError;
+  for (let i = 0; i < attempts; i += 1) {
+    try {
+      return action();
+    } catch (err) {
+      lastError = err;
+      if (i === attempts - 1) break;
+      const delay = 750 + i * 350;
+      console.log(`[*] ${label} was blocked (${err.code || err.message}). Retrying in ${delay}ms...`);
+      await sleep(delay);
+    }
+  }
+  throw lastError;
+}
+
+async function withUpdateLock(action) {
+  const lockPath = path.join(os.tmpdir(), "matrix-iptv-update.lock");
+  let fd;
+
   try {
-    oldSize = fs.statSync(binaryPath).size;
-  } catch (e) {}
+    if (fs.existsSync(lockPath)) {
+      const ageMs = Date.now() - fs.statSync(lockPath).mtimeMs;
+      if (ageMs > 30 * 60 * 1000) {
+        fs.rmSync(lockPath, { force: true });
+      }
+    }
+
+    fd = fs.openSync(lockPath, "wx");
+    fs.writeSync(fd, `${process.pid}\n${new Date().toISOString()}\n`);
+  } catch (err) {
+    if (err.code === "EEXIST") {
+      throw new Error("Another Matrix IPTV update is already running. Try again after it finishes.");
+    }
+    throw err;
+  }
 
   try {
-    await download(releaseUrl, tempPath);
+    return await action();
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+    fs.rmSync(lockPath, { force: true });
+  }
+}
 
-    // Verify the downloaded file is not empty and is a valid size
-    const newSize = fs.statSync(tempPath).size;
-    if (newSize < 1024 * 100) { // Less than 100KB is almost certainly not a valid binary
-      throw new Error(`Downloaded file is too small (${newSize} bytes). Update may have failed.`);
-    }
+async function installBinary(tempPath, expectedVersion) {
+  const backupPath = `${binaryPath}.old-${Date.now()}${os.platform() === "win32" ? ".exe" : ""}`;
+  let backupCreated = false;
 
-    if (os.platform() !== "win32") {
-      fs.chmodSync(tempPath, "755");
-
-      // On macOS, remove quarantine flag to prevent Gatekeeper blocking
-      if (os.platform() === "darwin") {
-        try {
-          const { execSync } = require("child_process");
-          execSync(
-            `xattr -d com.apple.quarantine "${tempPath}" 2>/dev/null || true`
-          );
-          console.log(`[+] macOS quarantine flag cleared.`);
-        } catch (e) {
-          // xattr might fail silently, that's okay
-        }
+  try {
+    await retry("Replacing binary", () => {
+      if (fs.existsSync(binaryPath) && !backupCreated) {
+        fs.renameSync(binaryPath, backupPath);
+        backupCreated = true;
       }
+      fs.renameSync(tempPath, binaryPath);
+    });
+  } catch (err) {
+    if (backupCreated && !fs.existsSync(binaryPath) && fs.existsSync(backupPath)) {
+      fs.renameSync(backupPath, binaryPath);
+    }
+    throw err;
+  }
+
+  try {
+    makeExecutable(binaryPath);
+    const installedVersion = getBinaryVersion(binaryPath);
+    if (installedVersion !== expectedVersion) {
+      throw new Error(`Installed binary reports version ${installedVersion || "unknown"}, expected ${expectedVersion}.`);
     }
 
-    // Replace old binary
-    let attempts = 0;
-    const maxAttempts = 15;
-    while (attempts < maxAttempts) {
-      try {
-        if (fs.existsSync(binaryPath)) {
-          if (os.platform() === "win32") {
-            const oldPath = binaryPath + ".old." + Date.now();
-            fs.renameSync(binaryPath, oldPath);
-            try {
-              fs.unlinkSync(oldPath);
-            } catch (e) {
-              // Mark for deletion on next reboot or just ignore
-            }
-          } else {
-            fs.unlinkSync(binaryPath);
-          }
-        }
-        fs.renameSync(tempPath, binaryPath);
-        break;
-      } catch (e) {
-        attempts++;
-        if (attempts === maxAttempts) throw e;
-        await new Promise((r) => setTimeout(r, 1000 + attempts * 500));
-      }
-    }
-
-    if (os.platform() === "darwin") {
-      try {
-        const { execSync } = require("child_process");
-        execSync(`xattr -d com.apple.quarantine "${binaryPath}" 2>/dev/null || true`);
-      } catch (e) {}
-    }
-
-    // Loop detection: if the new binary is the exact same size as the old one,
-    // the update likely downloaded the same version. Don't relaunch to avoid an infinite loop.
-    if (oldSize > 0 && newSize === oldSize) {
-      console.log(`[!] Update downloaded but binary size unchanged (${newSize} bytes).`);
-      console.log(`[!] You may already be on the latest available binary. Skipping relaunch.`);
-      process.exit(0);
-    }
-
-    console.log(`[+] Update complete. Rebooting system...\n`);
-
-    if (os.platform() === "win32") {
-      // Give Windows time to release filesystem locks on the new binary
-      await new Promise((r) => setTimeout(r, 1500));
-
-      const batchScript = `
-@echo off
-timeout /t 3 /nobreak > nul
-start "" "${binaryPath}" %*
-del "%~f0"
-`;
-      const batchPath = path.join(os.tmpdir(), "matrix-relaunch.bat");
-      fs.writeFileSync(batchPath, batchScript);
-
-      // Brief delay to let AV scanners release locks on newly written files
-      await new Promise((r) => setTimeout(r, 500));
-
-      let spawnAttempts = 0;
-      const maxSpawnAttempts = 5;
-      while (spawnAttempts < maxSpawnAttempts) {
-        try {
-          spawn("cmd.exe", ["/c", batchPath, ...process.argv.slice(2)], {
-            detached: true,
-            stdio: "ignore",
-            windowsHide: true,
-          }).unref();
-          process.exit(0);
-        } catch (spawnErr) {
-          spawnAttempts++;
-          if (spawnAttempts === maxSpawnAttempts) throw spawnErr;
-          console.log(`[*] Relaunch blocked by OS. Retrying (${spawnAttempts}/${maxSpawnAttempts})...`);
-          await new Promise((r) => setTimeout(r, 1000 + spawnAttempts * 500));
-        }
-      }
+    if (backupCreated) {
+      fs.rmSync(backupPath, { force: true });
     }
   } catch (err) {
-    if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
+    console.log("[!] Installed binary failed verification. Restoring previous binary...");
+    fs.rmSync(binaryPath, { force: true });
+    if (backupCreated && fs.existsSync(backupPath)) {
+      fs.renameSync(backupPath, binaryPath);
+    }
     throw err;
   }
 }
 
-function launchApp(isUpdateRelaunch = false) {
+async function performUpdate(options = {}) {
+  const targetVersion = options.targetVersion || null;
+  const relaunch = Boolean(options.relaunch);
+  const relaunchArgs = options.relaunchArgs || [];
+
+  return withUpdateLock(async () => {
+    const release = await fetchRelease(targetVersion);
+    const releaseVersion = String(release.tag_name || "").replace(/^v/i, "");
+    const currentVersion = currentInstalledVersion();
+
+    if (!releaseVersion) {
+      throw new Error("GitHub release did not include a tag name.");
+    }
+
+    console.log(`\n[*] Matrix IPTV update check`);
+    console.log(`[*] Current: ${currentVersion || "unknown"}`);
+    console.log(`[*] Target : ${releaseVersion}`);
+
+    if (currentVersion && compareVersions(currentVersion, releaseVersion) >= 0) {
+      console.log("[+] Matrix IPTV is already up to date.");
+      return { updated: false, version: currentVersion };
+    }
+
+    const asset = selectAsset(release);
+    const tempName =
+      os.platform() === "win32"
+        ? `matrix-iptv-${process.pid}-${Date.now()}.download.exe`
+        : `matrix-iptv-${process.pid}-${Date.now()}.download`;
+    const tempPath = path.join(path.dirname(binaryPath), tempName);
+
+    try {
+      console.log(`[*] Downloading ${asset.name} from ${release.tag_name}...`);
+      await downloadAsset(asset, tempPath);
+      verifyDownloadedBinary(tempPath, asset, releaseVersion);
+      await installBinary(tempPath, releaseVersion);
+      console.log(`[+] Updated Matrix IPTV to ${releaseVersion}.`);
+
+      if (relaunch) {
+        console.log("[*] Restarting Matrix IPTV...");
+        launchApp(true, relaunchArgs);
+      } else {
+        console.log("[+] Run 'matrix-iptv' to start the updated app.");
+      }
+
+      return { updated: true, version: releaseVersion };
+    } catch (err) {
+      fs.rmSync(tempPath, { force: true });
+      throw err;
+    }
+  });
+}
+
+function parseUpdateArgs(args) {
+  let targetVersion = null;
+  let relaunch = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--launch") {
+      relaunch = true;
+    } else if (arg === "--target" || arg === "--version") {
+      targetVersion = args[i + 1];
+      i += 1;
+    } else if (arg.startsWith("--target=")) {
+      targetVersion = arg.slice("--target=".length);
+    } else if (arg.startsWith("--version=")) {
+      targetVersion = arg.slice("--version=".length);
+    } else if (/^v?\d+\.\d+\.\d+$/.test(arg)) {
+      targetVersion = arg;
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(`Usage:
+  matrix-iptv update
+  matrix-iptv update --target 4.3.2
+  matrix-iptv update --launch
+
+Downloads the GitHub release asset, verifies its size/checksum/version,
+installs it transactionally, and rolls back if verification fails.`);
+      process.exit(0);
+    }
+  }
+
+  return { targetVersion, relaunch };
+}
+
+function launchApp(isUpdateRelaunch = false, args = process.argv.slice(2)) {
   if (!fs.existsSync(binaryPath)) {
-    console.error("\n❌  Matrix IPTV binary not found.");
-    console.log(
-      "Try one of these:\n  npx matrix-iptv\n  npm install -g matrix-iptv\n"
-    );
+    console.error("\nMatrix IPTV binary not found.");
+    console.log("Try one of these:\n  matrix-iptv update\n  npm install -g matrix-iptv\n");
     process.exit(1);
   }
 
   let child;
   try {
-    child = spawn(binaryPath, process.argv.slice(2), {
+    child = spawn(binaryPath, args, {
       stdio: "inherit",
       windowsHide: false,
+      env: {
+        ...process.env,
+        MATRIX_IPTV_WRAPPER: "1",
+      },
     });
   } catch (err) {
-    if (isUpdateRelaunch && (err.code === "EBUSY" || err.code === "EACCES")) {
-      console.log(`[*] Executable locked by OS. Retrying in 2 seconds...`);
-      setTimeout(() => launchApp(true), 2000);
+    if (isUpdateRelaunch && (err.code === "EBUSY" || err.code === "EACCES" || err.code === "EPERM")) {
+      console.log("[*] Executable locked by OS. Retrying in 2 seconds...");
+      setTimeout(() => launchApp(true, args), 2000);
       return;
     }
     throw err;
   }
 
   child.on("error", (err) => {
-    if (isUpdateRelaunch && (err.code === "EBUSY" || err.code === "EACCES")) {
-      console.log(`[*] Executable locked by OS. Retrying in 2 seconds...`);
-      setTimeout(() => launchApp(true), 2000);
+    if (isUpdateRelaunch && (err.code === "EBUSY" || err.code === "EACCES" || err.code === "EPERM")) {
+      console.log("[*] Executable locked by OS. Retrying in 2 seconds...");
+      setTimeout(() => launchApp(true, args), 2000);
       return;
     }
     console.error("Failed to start Matrix IPTV:", err);
@@ -213,15 +387,12 @@ function launchApp(isUpdateRelaunch = false) {
   });
 
   child.on("exit", async (code) => {
-    if (code === 42) {
+    if (code === updateExitCode) {
       try {
-        await performUpdate();
-        // If not win32 (which handles its own relaunch), relaunch here
-        if (os.platform() !== "win32") {
-          launchApp(true);
-        }
+        await performUpdate({ relaunch: true, relaunchArgs: args });
       } catch (err) {
-        console.error(`\n❌ Update failed: ${err.message}`);
+        console.error(`\nUpdate failed: ${err.message}`);
+        console.error("The previous Matrix IPTV binary was left in place or restored.");
         process.exit(1);
       }
     } else {
@@ -230,4 +401,14 @@ function launchApp(isUpdateRelaunch = false) {
   });
 }
 
-launchApp();
+const args = process.argv.slice(2);
+if (args[0] === "update" || args[0] === "self-update" || args[0] === "--update") {
+  const updateArgs = parseUpdateArgs(args.slice(1));
+  performUpdate(updateArgs).catch((err) => {
+    console.error(`\nUpdate failed: ${err.message}`);
+    console.error("The previous Matrix IPTV binary was left in place or restored.");
+    process.exit(1);
+  });
+} else {
+  launchApp(false, args);
+}

--- a/scripts/install-binary.js
+++ b/scripts/install-binary.js
@@ -1,12 +1,17 @@
+const { spawnSync } = require("child_process");
+const crypto = require("crypto");
 const fs = require("fs");
-const path = require("path");
-const https = require("https");
 const os = require("os");
+const path = require("path");
+const axios = require("axios");
 
-const binaryName =
-  os.platform() === "win32" ? "matrix-iptv.exe" : "matrix-iptv";
+const repo = "officebeats/matrix-iptv";
+const userAgent = "matrix-iptv-installer";
+const packageVersion = require("../package.json").version;
+const binaryName = os.platform() === "win32" ? "matrix-iptv.exe" : "matrix-iptv";
 const binDir = path.join(__dirname, "..", "bin");
 const binaryPath = path.join(binDir, binaryName);
+const minBinarySize = 1024 * 100;
 
 const platformMap = {
   win32: "windows.exe",
@@ -14,108 +19,177 @@ const platformMap = {
   darwin: "macos",
 };
 
-const archMap = {
-  x64: "x64",
-  arm64: "arm64",
-};
-
-const platform = platformMap[os.platform()];
-if (!platform) {
-  console.error(`Unsupported platform: ${os.platform()}`);
+function fail(message) {
+  console.error(`\nInstallation failed: ${message}`);
+  console.error("Please check the GitHub release assets or reinstall with npm install -g matrix-iptv.");
   process.exit(1);
 }
 
-// Note: Re-using the naming convention from install.ps1
-// https://github.com/officebeats/matrix-iptv/releases/latest/download/matrix-iptv-windows.exe
-const releaseUrl = `https://github.com/officebeats/matrix-iptv/releases/latest/download/matrix-iptv-${platform}`;
-
-console.log(`[*] Matrix IPTV // Binary Bootstrap`);
-console.log(`[*] Platform: ${os.platform()} (${os.arch()})`);
-console.log(`[*] Downloading: ${releaseUrl}`);
-
-if (!fs.existsSync(binDir)) {
-  fs.mkdirSync(binDir, { recursive: true });
+function parseVersion(output) {
+  const match = String(output || "").match(/(\d+\.\d+\.\d+)/);
+  return match ? match[1] : null;
 }
 
-function download(url, dest) {
-  return new Promise((resolve, reject) => {
-    https
-      .get(url, (response) => {
-        if (response.statusCode === 302 || response.statusCode === 301 || response.statusCode === 307 || response.statusCode === 308) {
-          // Handle Redirect without leaving locks open
-          download(response.headers.location, dest).then(resolve).catch(reject);
-          return;
-        }
-        
-        if (response.statusCode !== 200) {
-          reject(new Error(`Failed to download: ${response.statusCode}`));
-          return;
-        }
+function sha256(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
 
-        // Only open the file stream if the download actually works
-        const file = fs.createWriteStream(dest);
-        response.pipe(file);
-        
-        file.on("finish", () => {
-          file.close();
-          resolve();
-        });
-        
-        file.on("error", (err) => {
-          file.close();
-          fs.unlink(dest, () => {});
-          reject(err);
-        });
-      })
-      .on("error", (err) => {
-        reject(err);
-      });
+async function fetchRelease() {
+  const response = await axios.get(
+    `https://api.github.com/repos/${repo}/releases/tags/v${packageVersion}`,
+    {
+      timeout: 15000,
+      headers: {
+        Accept: "application/vnd.github+json",
+        "Cache-Control": "no-cache",
+        "User-Agent": userAgent,
+      },
+    }
+  );
+
+  return response.data;
+}
+
+function selectAsset(release) {
+  const platform = platformMap[os.platform()];
+  if (!platform) {
+    fail(`Unsupported platform: ${os.platform()}`);
+  }
+
+  const expectedName = `matrix-iptv-${platform}`;
+  const asset = (release.assets || []).find((item) => item.name === expectedName);
+  if (!asset) {
+    fail(`Release ${release.tag_name} does not include ${expectedName}.`);
+  }
+
+  return asset;
+}
+
+async function download(url, destination) {
+  const response = await axios({
+    method: "get",
+    url,
+    responseType: "stream",
+    timeout: 60000,
+    headers: {
+      "Cache-Control": "no-cache",
+      "User-Agent": userAgent,
+    },
+  });
+
+  await new Promise((resolve, reject) => {
+    const writer = fs.createWriteStream(destination, { flags: "wx" });
+    response.data.pipe(writer);
+    writer.on("finish", () => writer.close(resolve));
+    writer.on("error", (err) => {
+      fs.rm(destination, { force: true }, () => {});
+      reject(err);
+    });
   });
 }
 
-const tempPath = binaryPath + ".tmp";
+function makeExecutable(filePath) {
+  if (os.platform() !== "win32") {
+    fs.chmodSync(filePath, 0o755);
+  }
 
-download(releaseUrl, tempPath)
-  .then(async () => {
-    console.log(`[+] Download complete.`);
+  if (os.platform() === "darwin") {
+    spawnSync("xattr", ["-d", "com.apple.quarantine", filePath], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+  }
+}
 
-    // Replace old binary with robustness logic for Windows
-    let attempts = 0;
-    const maxAttempts = 5;
-    while (attempts < maxAttempts) {
+function verifyBinary(filePath, asset) {
+  const stat = fs.statSync(filePath);
+  if (stat.size < minBinarySize) {
+    fail(`Downloaded file is too small (${stat.size} bytes).`);
+  }
+
+  if (asset.size && stat.size !== asset.size) {
+    fail(`Downloaded file size mismatch: expected ${asset.size}, got ${stat.size}.`);
+  }
+
+  if (asset.digest && asset.digest.startsWith("sha256:")) {
+    const expectedDigest = asset.digest.slice("sha256:".length).toLowerCase();
+    const actualDigest = sha256(filePath);
+    if (actualDigest !== expectedDigest) {
+      fail("Downloaded binary checksum did not match the GitHub release asset digest.");
+    }
+  } else {
+    console.log("[!] GitHub did not provide a release asset digest; continuing with size and version checks.");
+  }
+
+  makeExecutable(filePath);
+
+  const result = spawnSync(filePath, ["--version"], {
+    encoding: "utf8",
+    timeout: 10000,
+    windowsHide: true,
+    env: {
+      ...process.env,
+      MATRIX_IPTV_WRAPPER: "1",
+      MATRIX_IPTV_SKIP_UPDATE: "1",
+    },
+  });
+
+  if (result.error) {
+    fail(`Unable to run downloaded binary: ${result.error.message}`);
+  }
+
+  const version = parseVersion(`${result.stdout}\n${result.stderr}`);
+  if (result.status !== 0 || version !== packageVersion) {
+    fail(`Downloaded binary reports version ${version || "unknown"}, expected ${packageVersion}.`);
+  }
+}
+
+async function install() {
+  if (!fs.existsSync(binDir)) {
+    fs.mkdirSync(binDir, { recursive: true });
+  }
+
+  const tempPath = path.join(
+    binDir,
+    os.platform() === "win32"
+      ? `matrix-iptv-${process.pid}.download.exe`
+      : `matrix-iptv-${process.pid}.download`
+  );
+
+  console.log("[*] Matrix IPTV binary bootstrap");
+  console.log(`[*] Platform: ${os.platform()} (${os.arch()})`);
+  console.log(`[*] Package version: ${packageVersion}`);
+
+  try {
+    const release = await fetchRelease();
+    const asset = selectAsset(release);
+    console.log(`[*] Downloading ${asset.name} from ${release.tag_name}...`);
+    await download(asset.browser_download_url, tempPath);
+    verifyBinary(tempPath, asset);
+
+    if (fs.existsSync(binaryPath)) {
+      const backupPath = `${binaryPath}.old-${Date.now()}${os.platform() === "win32" ? ".exe" : ""}`;
+      fs.renameSync(binaryPath, backupPath);
       try {
-        if (fs.existsSync(binaryPath)) {
-          if (os.platform() === "win32") {
-            const oldPath = binaryPath + ".old." + Date.now();
-            fs.renameSync(binaryPath, oldPath);
-            try {
-              fs.unlinkSync(oldPath);
-            } catch (e) {}
-          } else {
-            fs.unlinkSync(binaryPath);
-          }
-        }
         fs.renameSync(tempPath, binaryPath);
-        break;
-      } catch (e) {
-        attempts++;
-        if (attempts === maxAttempts) throw e;
-        await new Promise((r) => setTimeout(r, 1000));
+        fs.rmSync(backupPath, { force: true });
+      } catch (err) {
+        if (!fs.existsSync(binaryPath) && fs.existsSync(backupPath)) {
+          fs.renameSync(backupPath, binaryPath);
+        }
+        throw err;
       }
+    } else {
+      fs.renameSync(tempPath, binaryPath);
     }
 
-    if (os.platform() !== "win32") {
-      fs.chmodSync(binaryPath, "755");
-      console.log(`[+] Executable permissions set.`);
-    }
+    makeExecutable(binaryPath);
+    console.log("[+] Matrix IPTV binary ready.");
+    console.log("Type 'matrix-iptv' to start.");
+  } catch (err) {
+    fs.rmSync(tempPath, { force: true });
+    fail(err.message);
+  }
+}
 
-    console.log(`\n✅  Matrix IPTV binary ready.`);
-    console.log(`Type 'matrix-iptv' to start.`);
-  })
-  .catch((err) => {
-    console.error(`\n❌ Installation failed: ${err.message}`);
-    console.log(
-      `Please ensure the GitHub repository is public and has a 'latest' release.`
-    );
-    process.exit(1);
-  });
+install();

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -3463,6 +3463,12 @@ pub async fn handle_key_event(
                     }
                     app.current_screen = CurrentScreen::Home;
                 }
+                KeyCode::Char('s') | KeyCode::Char('S') => {
+                    if let Some(ref version) = app.new_version_available {
+                        crate::setup::skip_update(version);
+                    }
+                    app.current_screen = CurrentScreen::Home;
+                }
                 _ => {}
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,9 @@ use tokio::sync::mpsc;
 #[derive(clap::Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
+    #[command(subcommand)]
+    command: Option<Command>,
+
     /// Optional Direct Play URL (if provided, plays and exits)
     #[arg(short, long)]
     play: Option<String>,
@@ -35,6 +38,12 @@ struct Args {
     skip_update: bool,
 }
 
+#[derive(clap::Subcommand, Debug)]
+enum Command {
+    /// Update the installed Matrix IPTV binary from the latest GitHub release
+    Update,
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -42,6 +51,23 @@ async fn main() -> Result<(), anyhow::Error> {
     let args = Args::parse();
 
     // -- CLI MODE --
+    if let Some(Command::Update) = args.command {
+        #[cfg(target_os = "windows")]
+        {
+            setup::perform_windows_self_update()?;
+            println!("Matrix IPTV updater launched. The app will reopen when the update finishes.");
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            println!("For npm installs, run: matrix-iptv update");
+            println!("For standalone binaries, download the latest release asset from:");
+            println!("https://github.com/officebeats/matrix-iptv/releases/latest");
+        }
+
+        return Ok(());
+    }
+
     if args.check {
         setup::check_and_install_dependencies()?;
         println!("Checking configuration...");
@@ -164,21 +190,23 @@ async fn main() -> Result<(), anyhow::Error> {
     };
 
     if exit_code == 42 {
-        // On Windows, handle the update directly from the binary to avoid
-        // the EBUSY bug in older versions of cli.js
         #[cfg(target_os = "windows")]
         {
-            if let Err(e) = setup::perform_windows_self_update() {
-                eprintln!(
-                    "\n[!] Self-update failed: {}. Falling back to CLI updater.",
-                    e
-                );
-                std::process::exit(42);
+            // New npm wrappers provide a safer transactional updater. Keep the
+            // Rust fallback for standalone binaries and old wrappers that do not
+            // mark child launches with MATRIX_IPTV_WRAPPER.
+            if std::env::var_os("MATRIX_IPTV_WRAPPER").is_none() {
+                if let Err(e) = setup::perform_windows_self_update() {
+                    eprintln!(
+                        "\n[!] Self-update failed: {}. Falling back to CLI updater.",
+                        e
+                    );
+                    std::process::exit(42);
+                }
+                std::process::exit(0);
             }
-            std::process::exit(0);
         }
 
-        #[cfg(not(target_os = "windows"))]
         std::process::exit(42);
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -391,6 +391,13 @@ fn get_update_cooldown_path() -> Option<std::path::PathBuf> {
         .map(|dirs| dirs.config_dir().join(".update_cooldown"))
 }
 
+/// Returns the path to the skipped update file (stored next to config).
+#[cfg(not(target_arch = "wasm32"))]
+fn get_update_skip_path() -> Option<std::path::PathBuf> {
+    directories::ProjectDirs::from("", "", "matrix-iptv")
+        .map(|dirs| dirs.config_dir().join(".update_skip"))
+}
+
 /// Check if an update for the given version was recently dismissed (within cooldown_hours)
 #[cfg(not(target_arch = "wasm32"))]
 fn is_update_dismissed(version: &str, cooldown_hours: u64) -> bool {
@@ -419,6 +426,19 @@ fn is_update_dismissed(version: &str, cooldown_hours: u64) -> bool {
     false
 }
 
+/// Check if a specific update version was explicitly skipped.
+#[cfg(not(target_arch = "wasm32"))]
+fn is_update_skipped(version: &str) -> bool {
+    let path = match get_update_skip_path() {
+        Some(p) => p,
+        None => return false,
+    };
+
+    std::fs::read_to_string(&path)
+        .map(|content| content.trim() == version)
+        .unwrap_or(false)
+}
+
 /// Record that the user dismissed an update for a specific version
 #[cfg(not(target_arch = "wasm32"))]
 pub fn dismiss_update(version: &str) {
@@ -434,11 +454,26 @@ pub fn dismiss_update(version: &str) {
     }
 }
 
+/// Record that the user wants to skip a specific update version.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn skip_update(version: &str) {
+    if let Some(path) = get_update_skip_path() {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(&path, version);
+    }
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn check_for_updates(
     tx: tokio::sync::mpsc::Sender<crate::app::AsyncAction>,
     manual: bool,
 ) {
+    if std::env::var_os("MATRIX_IPTV_SKIP_UPDATE").is_some() {
+        return;
+    }
+
     let current_version = env!("CARGO_PKG_VERSION");
     let client = reqwest::Client::builder()
         .user_agent("matrix-iptv-cli-updater")
@@ -446,28 +481,37 @@ pub async fn check_for_updates(
         .build()
         .unwrap_or_default();
 
-    // Use a GET request to the latest release to check the tag
-    // GitHub redirects /latest to the specific tag URL
     if let Ok(resp) = client
-        .get("https://github.com/officebeats/matrix-iptv/releases/latest")
+        .get("https://api.github.com/repos/officebeats/matrix-iptv/releases/latest")
         .send()
         .await
     {
-        let final_url = resp.url().to_string();
-        // URL is likely https://github.com/officebeats/matrix-iptv/releases/tag/v3.0.9
-        if let Some(tag) = final_url.split("/tag/").last() {
-            let tag = tag.trim_start_matches('v');
-            if is_newer_version(current_version, tag) {
-                // For automatic (non-manual) checks: skip if user dismissed this version recently
-                if !manual && is_update_dismissed(tag, 24) {
-                    return; // User dismissed this version within the last 24 hours
+        let tag = resp
+            .json::<serde_json::Value>()
+            .await
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("tag_name")
+                    .and_then(|tag| tag.as_str())
+                    .map(|tag| tag.trim_start_matches('v').to_string())
+            });
+
+        if let Some(tag) = tag {
+            if is_newer_version(current_version, &tag) {
+                if !manual && (is_update_dismissed(&tag, 24) || is_update_skipped(&tag)) {
+                    return;
                 }
-                let _ = tx
-                    .send(crate::app::AsyncAction::UpdateAvailable(tag.to_string()))
-                    .await;
+                let _ = tx.send(crate::app::AsyncAction::UpdateAvailable(tag)).await;
             } else if manual {
                 let _ = tx.send(crate::app::AsyncAction::NoUpdateFound).await;
             }
+        } else if manual {
+            let _ = tx
+                .send(crate::app::AsyncAction::Error(
+                    "Failed to read the latest GitHub release version.".to_string(),
+                ))
+                .await;
         }
     } else if manual {
         let _ = tx

--- a/src/ui/popups.rs
+++ b/src/ui/popups.rs
@@ -680,7 +680,7 @@ pub fn render_update_prompt(f: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(""),
         Line::from(vec![Span::styled(
-            "The update will be downloaded and installed automatically.",
+            "The updater verifies the download and restores the old binary if install fails.",
             Style::default().fg(TEXT_SECONDARY),
         )]),
     ];
@@ -706,7 +706,14 @@ pub fn render_update_prompt(f: &mut Frame, app: &App, area: Rect) {
                 .fg(ratatui::style::Color::Rgb(255, 100, 100))
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(" later", Style::default().fg(TEXT_PRIMARY)),
+        Span::styled(" later   ", Style::default().fg(TEXT_PRIMARY)),
+        Span::styled(
+            "s",
+            Style::default()
+                .fg(ratatui::style::Color::Rgb(255, 180, 80))
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" skip version", Style::default().fg(TEXT_PRIMARY)),
     ])])
     .alignment(Alignment::Center);
 


### PR DESCRIPTION
## Summary

This PR makes the Matrix IPTV self-update path safer for standard CLI usage.

- Adds `matrix-iptv update`, `matrix-iptv self-update`, and `matrix-iptv --update` in the npm wrapper.
- Downloads exact GitHub release assets for the target version instead of relying on loose latest-asset behavior.
- Verifies release asset size, GitHub-provided SHA-256 digest when available, and downloaded binary `--version` before install.
- Installs transactionally with a temporary file, backup binary, installed-version verification, and rollback on failure.
- Lets the Windows npm wrapper handle exit-code-42 updates while keeping the Rust fallback for standalone or older wrapper cases.
- Adds update prompt skip-version support and README guidance for terminal updates.

## Why

The existing update path could bypass the npm wrapper on Windows, used weak loop detection, and did not provide a strong rollback story if the downloaded or installed binary was invalid. The new flow is intended to be easy from terminal and difficult to leave broken after an interrupted or bad update.

## Validation

- `node --check bin/cli.js`
- `node --check scripts/install-binary.js`
- `node bin/cli.js update` installs missing binary from `v4.3.2`
- `node bin/cli.js update --target 4.3.2` reports already up to date
- `node scripts/install-binary.js` downloads and verifies `v4.3.2` binary
- `node bin/cli.js --version`
- `cargo fmt --check`
- `cargo clippy --all-targets`
- `cargo test --all-targets`
- `git diff --check`
- `npm pack --dry-run --json` for root package and scoped compatibility package

## Notes

This prepares the next release. The package version remains `4.3.2` until a follow-up release bump publishes this updater to users.