### PR TITLE
[codex] show sports scores in now playing

### DIFF
--- a/src/ui/panes.rs
+++ b/src/ui/panes.rs
@@ -32,6 +32,125 @@ fn format_relative_time(dt: DateTime<Utc>, user_tz: &Tz) -> String {
     format!("{} {}", day, local.format("%I:%M %p"))
 }
 
+fn is_current_live_category_sports(app: &App) -> bool {
+    matches!(
+        app.current_screen,
+        CurrentScreen::Categories | CurrentScreen::Streams
+    ) && app
+        .categories
+        .get(app.selected_category_index)
+        .map(|category| {
+            category.is_sports || crate::parser::is_sports_content(&category.category_name)
+        })
+        .unwrap_or(false)
+}
+
+fn score_start_time(score: &crate::scores::ScoreGame, user_tz: &Tz) -> Option<String> {
+    chrono::DateTime::parse_from_rfc3339(&score.start_time)
+        .ok()
+        .map(|dt| format_relative_time(dt.with_timezone(&Utc), user_tz))
+}
+
+fn sports_clock_text(score: &crate::scores::ScoreGame, user_tz: &Tz) -> String {
+    let detail = score.status_detail.trim();
+
+    match score.status_state.as_str() {
+        "post" => {
+            if detail.is_empty() {
+                "Final".to_string()
+            } else {
+                detail.to_string()
+            }
+        }
+        "in" => {
+            let clock = score
+                .display_clock
+                .split_whitespace()
+                .next()
+                .unwrap_or(score.display_clock.as_str())
+                .trim();
+
+            if !clock.is_empty() && clock != "00:00" {
+                if detail.is_empty() || detail == clock || detail.contains(clock) {
+                    clock.to_string()
+                } else {
+                    format!("{} - {}", clock, detail)
+                }
+            } else if !detail.is_empty() {
+                detail.to_string()
+            } else {
+                "LIVE".to_string()
+            }
+        }
+        _ => score_start_time(score, user_tz).unwrap_or_else(|| {
+            if detail.is_empty() {
+                "Scheduled".to_string()
+            } else {
+                detail.to_string()
+            }
+        }),
+    }
+}
+
+fn score_team_label(abbr: &str, team_name: &str) -> String {
+    let abbr = abbr.trim();
+    if !abbr.is_empty() {
+        return abbr.to_string();
+    }
+
+    team_name
+        .split_whitespace()
+        .last()
+        .unwrap_or(team_name)
+        .to_string()
+}
+
+fn sports_score_text(score: &crate::scores::ScoreGame) -> String {
+    format!(
+        "{} {}-{} {}",
+        score_team_label(&score.home_abbr, &score.home_team),
+        score.home_score,
+        score.away_score,
+        score_team_label(&score.away_abbr, &score.away_team)
+    )
+}
+
+fn sports_now_playing_cell(
+    score: &crate::scores::ScoreGame,
+    user_tz: &Tz,
+    is_blink_on: bool,
+) -> Cell<'static> {
+    let mut spans = Vec::new();
+
+    if score.status_state == "in" {
+        let live_color = if is_blink_on {
+            Color::Rgb(255, 100, 100)
+        } else {
+            TEXT_DIM
+        };
+        spans.push(Span::styled(
+            "● LIVE ",
+            Style::default().fg(live_color).add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    spans.push(Span::styled(
+        sports_clock_text(score, user_tz),
+        Style::default()
+            .fg(Color::Rgb(255, 200, 80))
+            .add_modifier(Modifier::BOLD),
+    ));
+    spans.push(Span::styled(" | ", Style::default().fg(TEXT_DIM)));
+    spans.push(Span::styled(
+        sports_score_text(score),
+        Style::default()
+            .fg(TEXT_PRIMARY)
+            .add_modifier(Modifier::BOLD),
+    ));
+
+    Cell::from(Line::from(spans))
+}
+
 /// Shared highlight style — subtle left bar + tinted background
 fn list_highlight_style() -> Style {
     Style::default()
@@ -332,7 +451,6 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
                         ),
                     ])),
                     Cell::from(""), // NOW PLAYING
-                    Cell::from(""), // HEALTH
                 ]);
             }
 
@@ -617,18 +735,31 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
                 }
             }
 
-            // 9. Network Health
-            let health = app
-                .sports
-                .stream_health_cache
-                .get(&s_id)
-                .copied()
-                .or(s.latency_ms);
-            let health_span = latency_to_bars(health);
-
-            // 10. EPG "Now Playing" column
+            // 9. EPG / sports "Now Playing" column
             let s_id_str = crate::api::get_id_str(&s.stream_id);
-            let epg_cell = if let Some(epg_title) = app.epg_cache.get(&s_id_str) {
+            let sports_now_playing_context =
+                is_current_live_category_sports(app) || parsed.sports_event.is_some();
+            let epg_cell = if sports_now_playing_context {
+                if let Some(score) = score_data {
+                    sports_now_playing_cell(score, &user_tz, is_blink_on)
+                } else if let Some(st) = parsed.start_time {
+                    Cell::from(Span::styled(
+                        format!("Starts {}", format_relative_time(st, &user_tz)),
+                        Style::default().fg(Color::Rgb(255, 200, 80)),
+                    ))
+                } else if let Some(epg_title) = app.epg_cache.get(&s_id_str) {
+                    if !epg_title.is_empty() {
+                        Cell::from(Span::styled(
+                            epg_title.clone(),
+                            Style::default().fg(Color::Rgb(140, 140, 180)),
+                        ))
+                    } else {
+                        Cell::from("")
+                    }
+                } else {
+                    Cell::from("")
+                }
+            } else if let Some(epg_title) = app.epg_cache.get(&s_id_str) {
                 if !epg_title.is_empty() {
                     Cell::from(Span::styled(
                         epg_title.clone(),
@@ -655,7 +786,6 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
                 Cell::from(quality_span),
                 Cell::from(Line::from(spans)),
                 epg_cell,
-                Cell::from(health_span),
             ])
             .style(row_style)
         })
@@ -695,7 +825,6 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
         Constraint::Length(7), // Quality [FHD]
         Constraint::Fill(3),   // Name / Info (primary)
         Constraint::Fill(1),   // NOW PLAYING (EPG)
-        Constraint::Length(6), // Health bars
     ];
 
     let header_style = Style::default()
@@ -707,7 +836,6 @@ pub fn render_streams_pane(f: &mut Frame, app: &mut App, area: Rect, border_colo
         Cell::from(" QUAL").style(header_style),
         Cell::from(" CHANNEL").style(header_style),
         Cell::from(" NOW PLAYING").style(header_style),
-        Cell::from("HEALTH").style(header_style),
     ])
     .height(1)
     .style(Style::default().bg(Color::Rgb(10, 25, 10))); // Subtle dark green header bg

--- a/tests/frontend_screens_test.rs
+++ b/tests/frontend_screens_test.rs
@@ -3,6 +3,7 @@ use matrix_iptv_lib::app::{App, CurrentScreen, Pane};
 use matrix_iptv_lib::flex_id::FlexId;
 use ratatui::backend::TestBackend;
 use ratatui::Terminal;
+use ratatui::{layout::Rect, style::Color};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -84,6 +85,31 @@ fn render_frame_text(app: &mut App) -> String {
         text.push('\n');
     }
     text
+}
+
+fn render_streams_pane_text(app: &mut App) -> String {
+    let backend = TestBackend::new(160, 16);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|f| {
+            matrix_iptv_lib::ui::panes::render_streams_pane(
+                f,
+                app,
+                Rect::new(0, 0, 160, 16),
+                Color::Green,
+            );
+        })
+        .unwrap();
+
+    let buffer = terminal.backend().buffer();
+    let mut output = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            output.push_str(buffer[(x, y)].symbol());
+        }
+        output.push('\n');
+    }
+    output
 }
 
 /// Generate N streams with unique names for strong8k-scale testing
@@ -584,5 +610,78 @@ fn test_cross_pane_search() {
     assert!(
         !app.streams.is_empty(),
         "Cross-pane search should find ESPN in streams"
+    );
+}
+
+// ─── Test 15: Sports Now Playing Column ───────────────────────────────────────
+
+#[test]
+fn test_sports_now_playing_shows_clock_score_and_removes_health_column() {
+    let mut app = App::new();
+    app.current_screen = CurrentScreen::Streams;
+    app.active_pane = Pane::Streams;
+    app.categories = vec![Arc::new(Category {
+        category_id: "nba".to_string(),
+        category_name: "NBA PACKAGE".to_string(),
+        is_sports: true,
+        ..Default::default()
+    })];
+    app.selected_category_index = 0;
+    app.streams = vec![make_stream(836349, "DETROIT PISTONS")];
+    app.selected_stream_index = 0;
+    app.session.loading_tick = 0;
+    app.live_scores = vec![matrix_iptv_lib::scores::ScoreGame {
+        id: "game-1".to_string(),
+        league: "NBA".to_string(),
+        start_time: "2026-05-03T20:00:00Z".to_string(),
+        status_state: "in".to_string(),
+        status_detail: "3rd".to_string(),
+        home_team: "Detroit Pistons".to_string(),
+        home_score: "64".to_string(),
+        home_abbr: "DET".to_string(),
+        home_color: None,
+        home_record: None,
+        home_logo: None,
+        away_team: "Orlando Magic".to_string(),
+        away_score: "51".to_string(),
+        away_abbr: "ORL".to_string(),
+        away_color: None,
+        away_record: None,
+        away_logo: None,
+        display_clock: "8:34".to_string(),
+        period: 3,
+        venue_name: None,
+        venue_city: None,
+        venue_state: None,
+        broadcasts: Vec::new(),
+        last_play: None,
+        home_win_pct: None,
+        away_win_pct: None,
+        headline: None,
+        series_summary: None,
+        top_scorer: None,
+    }];
+
+    let output = render_streams_pane_text(&mut app);
+
+    assert!(
+        output.contains("LIVE"),
+        "sports now-playing column should show a live marker for active games:\n{}",
+        output
+    );
+    assert!(
+        output.contains("8:34 - 3rd"),
+        "sports now-playing column should show the live game clock and period:\n{}",
+        output
+    );
+    assert!(
+        output.contains("DET 64-51 ORL"),
+        "sports now-playing column should show the compact score:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("HEALTH"),
+        "live streams table should not render the health column:\n{}",
+        output
     );
 }


### PR DESCRIPTION
## What changed

- Sports live categories now fill the live streams `NOW PLAYING` column with a blinking live marker, match clock, and compact score.
- Removed the `HEALTH` column from the live stream content list.
- Added a focused Ratatui render regression test for the NBA-style sports row output.

## Why

The NBA Package view already had score data available, but the table still reserved `NOW PLAYING` for EPG text and kept a separate health column. This makes sports rows show the live game state directly where users scan the list.

## Validation

- `cargo test --test frontend_screens_test test_sports_now_playing_shows_clock_score_and_removes_health_column`
- `cargo check --bin matrix-iptv`
- Manual Trex `US| NBA PACKAGE` verification showed `● LIVE ... | DET ... ORL` in `NOW PLAYING` and no `HEALTH` header.
- KiloCode review: no blocking findings; applied its non-blocking suggestion to make the blink-state test deterministic.