### PR TITLE
[codex] Fix updater status and compatibility

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,6 +10,7 @@ const axios = require("axios");
 const repo = "officebeats/matrix-iptv";
 const userAgent = "matrix-iptv-updater";
 const updateExitCode = 42;
+const updaterProtocol = "2";
 const minBinarySize = 1024 * 100;
 const binaryName = os.platform() === "win32" ? "matrix-iptv.exe" : "matrix-iptv";
 const binaryPath = path.join(__dirname, binaryName);
@@ -20,6 +21,56 @@ const platformMap = {
   linux: "linux",
   darwin: "macos",
 };
+
+function formatBytes(bytes) {
+  const value = Number(bytes || 0);
+  if (value < 1024) return `${value} B`;
+  const units = ["KB", "MB", "GB"];
+  let size = value / 1024;
+  let unit = units[0];
+  for (let i = 1; i < units.length && size >= 1024; i += 1) {
+    size /= 1024;
+    unit = units[i];
+  }
+  return `${size.toFixed(size >= 10 ? 1 : 2)} ${unit}`;
+}
+
+function createUpdateStatus(totalSteps = 6) {
+  let step = 0;
+
+  return {
+    step(message) {
+      step += 1;
+      console.log(`[${step}/${totalSteps}] ${message}`);
+    },
+    detail(message) {
+      console.log(`    ${message}`);
+    },
+  };
+}
+
+function createProgressReporter(status, expectedBytes) {
+  let lastPercent = -10;
+  let lastLoggedBytes = 0;
+
+  return (downloadedBytes, totalBytes) => {
+    const total = Number(totalBytes || expectedBytes || 0);
+
+    if (total > 0) {
+      const percent = Math.min(100, Math.floor((downloadedBytes / total) * 100));
+      if (percent !== lastPercent && (percent >= lastPercent + 10 || percent === 100)) {
+        status.detail(`Download ${percent}% (${formatBytes(downloadedBytes)} / ${formatBytes(total)})`);
+        lastPercent = percent;
+      }
+      return;
+    }
+
+    if (downloadedBytes - lastLoggedBytes >= 5 * 1024 * 1024) {
+      status.detail(`Downloaded ${formatBytes(downloadedBytes)}...`);
+      lastLoggedBytes = downloadedBytes;
+    }
+  };
+}
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -57,6 +108,7 @@ function getBinaryVersion(filePath) {
     env: {
       ...process.env,
       MATRIX_IPTV_WRAPPER: "1",
+      MATRIX_IPTV_UPDATER_PROTOCOL: updaterProtocol,
       MATRIX_IPTV_SKIP_UPDATE: "1",
     },
   });
@@ -114,7 +166,7 @@ function selectAsset(release) {
   return asset;
 }
 
-async function downloadAsset(asset, destination) {
+async function downloadAsset(asset, destination, onProgress = null) {
   const response = await axios({
     method: "get",
     url: asset.browser_download_url,
@@ -126,8 +178,17 @@ async function downloadAsset(asset, destination) {
     },
   });
 
+  const totalBytes = Number(response.headers["content-length"] || asset.size || 0);
+  let downloadedBytes = 0;
+
   await new Promise((resolve, reject) => {
     const writer = fs.createWriteStream(destination, { flags: "wx" });
+    response.data.on("data", (chunk) => {
+      downloadedBytes += chunk.length;
+      if (onProgress) {
+        onProgress(downloadedBytes, totalBytes);
+      }
+    });
     response.data.pipe(writer);
     writer.on("finish", () => writer.close(resolve));
     response.data.on("error", (err) => {
@@ -157,7 +218,7 @@ function makeExecutable(filePath) {
   }
 }
 
-function verifyDownloadedBinary(filePath, asset, expectedVersion) {
+function verifyDownloadedBinary(filePath, asset, expectedVersion, status = null) {
   const stat = fs.statSync(filePath);
   if (stat.size < minBinarySize) {
     throw new Error(`Downloaded file is too small (${stat.size} bytes).`);
@@ -166,6 +227,7 @@ function verifyDownloadedBinary(filePath, asset, expectedVersion) {
   if (asset.size && stat.size !== asset.size) {
     throw new Error(`Downloaded file size mismatch: expected ${asset.size}, got ${stat.size}.`);
   }
+  if (status) status.detail(`File size verified (${formatBytes(stat.size)}).`);
 
   if (asset.digest && asset.digest.startsWith("sha256:")) {
     const expectedDigest = asset.digest.slice("sha256:".length).toLowerCase();
@@ -173,6 +235,7 @@ function verifyDownloadedBinary(filePath, asset, expectedVersion) {
     if (actualDigest !== expectedDigest) {
       throw new Error("Downloaded binary checksum did not match the GitHub release asset digest.");
     }
+    if (status) status.detail("Checksum verified.");
   } else {
     console.log("[!] GitHub did not provide a release asset digest; continuing with size and version checks.");
   }
@@ -183,6 +246,7 @@ function verifyDownloadedBinary(filePath, asset, expectedVersion) {
   if (actualVersion !== expectedVersion) {
     throw new Error(`Downloaded binary reports version ${actualVersion || "unknown"}, expected ${expectedVersion}.`);
   }
+  if (status) status.detail(`Downloaded binary reports version ${actualVersion}.`);
 }
 
 async function retry(label, action, attempts = 15) {
@@ -230,7 +294,7 @@ async function withUpdateLock(action) {
   }
 }
 
-async function installBinary(tempPath, expectedVersion) {
+async function installBinary(tempPath, expectedVersion, beforeVerify = () => {}, status = null) {
   const backupPath = `${binaryPath}.old-${Date.now()}${os.platform() === "win32" ? ".exe" : ""}`;
   let backupCreated = false;
 
@@ -251,10 +315,12 @@ async function installBinary(tempPath, expectedVersion) {
 
   try {
     makeExecutable(binaryPath);
+    beforeVerify();
     const installedVersion = getBinaryVersion(binaryPath);
     if (installedVersion !== expectedVersion) {
       throw new Error(`Installed binary reports version ${installedVersion || "unknown"}, expected ${expectedVersion}.`);
     }
+    if (status) status.detail(`Installed binary reports version ${installedVersion}.`);
 
     if (backupCreated) {
       fs.rmSync(backupPath, { force: true });
@@ -275,6 +341,9 @@ async function performUpdate(options = {}) {
   const relaunchArgs = options.relaunchArgs || [];
 
   return withUpdateLock(async () => {
+    const status = createUpdateStatus();
+    console.log("\nMatrix IPTV update");
+    status.step("Resolving latest GitHub release");
     const release = await fetchRelease(targetVersion);
     const releaseVersion = String(release.tag_name || "").replace(/^v/i, "");
     const currentVersion = currentInstalledVersion();
@@ -283,12 +352,15 @@ async function performUpdate(options = {}) {
       throw new Error("GitHub release did not include a tag name.");
     }
 
-    console.log(`\n[*] Matrix IPTV update check`);
-    console.log(`[*] Current: ${currentVersion || "unknown"}`);
-    console.log(`[*] Target : ${releaseVersion}`);
+    status.detail(`Current: ${currentVersion || "unknown"}`);
+    status.detail(`Target : ${releaseVersion}`);
 
     if (currentVersion && compareVersions(currentVersion, releaseVersion) >= 0) {
       console.log("[+] Matrix IPTV is already up to date.");
+      if (relaunch) {
+        status.step("Relaunching Matrix IPTV");
+        launchApp(true, relaunchArgs);
+      }
       return { updated: false, version: currentVersion };
     }
 
@@ -300,14 +372,21 @@ async function performUpdate(options = {}) {
     const tempPath = path.join(path.dirname(binaryPath), tempName);
 
     try {
-      console.log(`[*] Downloading ${asset.name} from ${release.tag_name}...`);
-      await downloadAsset(asset, tempPath);
-      verifyDownloadedBinary(tempPath, asset, releaseVersion);
-      await installBinary(tempPath, releaseVersion);
+      status.step(`Downloading ${asset.name} from ${release.tag_name}`);
+      await downloadAsset(asset, tempPath, createProgressReporter(status, asset.size));
+      status.step("Verifying downloaded binary");
+      verifyDownloadedBinary(tempPath, asset, releaseVersion, status);
+      status.step("Installing update");
+      await installBinary(
+        tempPath,
+        releaseVersion,
+        () => status.step("Verifying installed binary"),
+        status
+      );
       console.log(`[+] Updated Matrix IPTV to ${releaseVersion}.`);
 
       if (relaunch) {
-        console.log("[*] Restarting Matrix IPTV...");
+        status.step("Relaunching Matrix IPTV");
         launchApp(true, relaunchArgs);
       } else {
         console.log("[+] Run 'matrix-iptv' to start the updated app.");
@@ -368,6 +447,7 @@ function launchApp(isUpdateRelaunch = false, args = process.argv.slice(2)) {
       env: {
         ...process.env,
         MATRIX_IPTV_WRAPPER: "1",
+        MATRIX_IPTV_UPDATER_PROTOCOL: updaterProtocol,
       },
     });
   } catch (err) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ async fn main() -> Result<(), anyhow::Error> {
     }
 
     if args.check {
-        setup::check_and_install_dependencies()?;
+        setup::check_and_install_dependencies_verbose()?;
         println!("Checking configuration...");
         // Reuse verification logic (simplified)
         // For now just print ok as verifying needs full async client setup which is in TUI logic
@@ -192,10 +192,15 @@ async fn main() -> Result<(), anyhow::Error> {
     if exit_code == 42 {
         #[cfg(target_os = "windows")]
         {
-            // New npm wrappers provide a safer transactional updater. Keep the
-            // Rust fallback for standalone binaries and old wrappers that do not
-            // mark child launches with MATRIX_IPTV_WRAPPER.
-            if std::env::var_os("MATRIX_IPTV_WRAPPER").is_none() {
+            // Protocol-aware npm wrappers can update the child binary after it
+            // exits. Standalone installs and older wrappers fall back to the
+            // Rust-launched updater so old wrapper code does not remain in the
+            // update path forever.
+            let has_protocol_updater = std::env::var("MATRIX_IPTV_UPDATER_PROTOCOL")
+                .ok()
+                .as_deref()
+                == Some("2");
+            if !has_protocol_updater {
                 if let Err(e) = setup::perform_windows_self_update() {
                     eprintln!(
                         "\n[!] Self-update failed: {}. Falling back to CLI updater.",

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,6 +1,4 @@
 #[cfg(not(target_arch = "wasm32"))]
-use std::io::{self, Write};
-#[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
 #[cfg(not(target_arch = "wasm32"))]
 use std::process::Command;
@@ -114,39 +112,65 @@ pub fn get_vlc_path() -> Option<String> {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn check_and_install_dependencies() -> Result<(), anyhow::Error> {
-    print!("Checking dependencies... ");
-    io::stdout().flush()?;
+    check_and_install_dependencies_with_output(false)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn check_and_install_dependencies_verbose() -> Result<(), anyhow::Error> {
+    check_and_install_dependencies_with_output(true)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn check_and_install_dependencies_with_output(verbose: bool) -> Result<(), anyhow::Error> {
+    let mut announced = false;
+    let mut announce = || -> Result<(), anyhow::Error> {
+        if !announced {
+            println!("Checking dependencies...");
+            announced = true;
+        }
+        Ok(())
+    };
+
+    if verbose {
+        announce()?;
+    }
 
     if let Some(mpv_path) = get_mpv_path() {
-        if mpv_path == "mpv" {
-            print!("✓ mpv found. ");
-        } else {
-            print!("✓ mpv found at: {}. ", mpv_path);
+        if verbose {
+            if mpv_path == "mpv" {
+                println!("  ✓ mpv found.");
+            } else {
+                println!("  ✓ mpv found at: {}", mpv_path);
+            }
         }
     } else {
-        println!("\n✗ mpv NOT found.");
+        announce()?;
+        println!("  ✗ mpv NOT found.");
         if cfg!(target_os = "windows") {
-            println!("Attempting to install mpv using winget...");
+            println!("  Attempting to install mpv using winget...");
             install_mpv_windows()?;
         } else if cfg!(target_os = "macos") {
-            println!("Attempting to install mpv using homebrew...");
+            println!("  Attempting to install mpv using homebrew...");
             install_mpv_macos()?;
         }
     }
 
     if let Some(vlc_path) = get_vlc_path() {
-        if vlc_path == "vlc" {
-            println!("✓ vlc found.");
-        } else {
-            println!("✓ vlc found at: {}", vlc_path);
+        if verbose {
+            if vlc_path == "vlc" {
+                println!("  ✓ vlc found.");
+            } else {
+                println!("  ✓ vlc found at: {}", vlc_path);
+            }
         }
     } else {
-        println!("\n✗ vlc NOT found.");
+        announce()?;
+        println!("  ✗ vlc NOT found.");
         if cfg!(target_os = "windows") {
-            println!("Attempting to install vlc using winget...");
+            println!("  Attempting to install vlc using winget...");
             install_vlc_windows()?;
         } else if cfg!(target_os = "macos") {
-            println!("Attempting to install vlc using homebrew...");
+            println!("  Attempting to install vlc using homebrew...");
             install_vlc_macos()?;
         }
     }
@@ -523,8 +547,9 @@ pub async fn check_for_updates(
 }
 
 /// On Windows, perform the self-update directly from the Rust binary.
-/// This bypasses cli.js entirely (which may be an older version with the EBUSY bug).
-/// Writes a PowerShell script that downloads the new binary, replaces the old one, and relaunches.
+/// This is the fallback for standalone binaries and older wrappers. The npm
+/// wrapper remains the preferred path because it can replace the child binary
+/// after the app exits, but this helper keeps standalone installs reliable too.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn perform_windows_self_update() -> Result<(), anyhow::Error> {
     let current_exe = std::env::current_exe()?;
@@ -532,20 +557,64 @@ pub fn perform_windows_self_update() -> Result<(), anyhow::Error> {
     let ps_script_template = r#"
 # Matrix IPTV Self-Update Script
 $ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
 Start-Sleep -Seconds 2
 
 $exePath = "__EXE_PATH__"
 $tempPath = "$exePath.update.tmp"
 $backupPath = "$exePath.old.$([DateTimeOffset]::Now.ToUnixTimeMilliseconds())"
 $minBinarySize = 102400
+$step = 0
+$totalSteps = 6
+
+function Write-Step($message) {
+    $script:step += 1
+    Write-Host "[$script:step/$script:totalSteps] $message" -ForegroundColor Cyan
+}
+
+function Write-Detail($message) {
+    Write-Host "    $message" -ForegroundColor DarkGray
+}
+
+function Format-Bytes([int64]$bytes) {
+    if ($bytes -lt 1024) { return "$bytes B" }
+    $units = @('KB', 'MB', 'GB')
+    $size = [double]$bytes / 1024
+    $unit = $units[0]
+    for ($i = 1; $i -lt $units.Length -and $size -ge 1024; $i++) {
+        $size = $size / 1024
+        $unit = $units[$i]
+    }
+    if ($size -ge 10) {
+        return ("{0:N1} {1}" -f $size, $unit)
+    }
+    return ("{0:N2} {1}" -f $size, $unit)
+}
 
 function Get-MatrixVersion($path) {
-    $env:MATRIX_IPTV_WRAPPER = '1'
-    $env:MATRIX_IPTV_SKIP_UPDATE = '1'
-    $output = & $path --version 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        throw "Version check failed for ${path}: $output"
+    $oldWrapper = $env:MATRIX_IPTV_WRAPPER
+    $oldSkipUpdate = $env:MATRIX_IPTV_SKIP_UPDATE
+    try {
+        $env:MATRIX_IPTV_WRAPPER = '1'
+        $env:MATRIX_IPTV_SKIP_UPDATE = '1'
+        $output = & $path --version 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Version check failed for ${path}: $output"
+        }
+    } finally {
+        if ($null -eq $oldWrapper) {
+            Remove-Item Env:\MATRIX_IPTV_WRAPPER -ErrorAction SilentlyContinue
+        } else {
+            $env:MATRIX_IPTV_WRAPPER = $oldWrapper
+        }
+
+        if ($null -eq $oldSkipUpdate) {
+            Remove-Item Env:\MATRIX_IPTV_SKIP_UPDATE -ErrorAction SilentlyContinue
+        } else {
+            $env:MATRIX_IPTV_SKIP_UPDATE = $oldSkipUpdate
+        }
     }
+
     $match = [regex]::Match(($output -join "`n"), '(\d+\.\d+\.\d+)')
     if (-not $match.Success) {
         throw "Could not read Matrix IPTV version from ${path}"
@@ -553,18 +622,98 @@ function Get-MatrixVersion($path) {
     return $match.Groups[1].Value
 }
 
+function Download-MatrixAsset($url, $destination, [int64]$expectedBytes) {
+    Add-Type -AssemblyName System.Net.Http
+
+    if (Test-Path $destination) {
+        Remove-Item $destination -Force
+    }
+
+    $client = [System.Net.Http.HttpClient]::new()
+    try {
+        $client.Timeout = [TimeSpan]::FromSeconds(120)
+        $client.DefaultRequestHeaders.UserAgent.ParseAdd('matrix-iptv-cli-updater')
+        $client.DefaultRequestHeaders.Add('Cache-Control', 'no-cache')
+
+        $request = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Get, $url)
+        $response = $client.SendAsync($request, [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead).GetAwaiter().GetResult()
+        $response.EnsureSuccessStatusCode() | Out-Null
+
+        [int64]$totalBytes = 0
+        if ($response.Content.Headers.ContentLength.HasValue) {
+            $totalBytes = $response.Content.Headers.ContentLength.Value
+        } elseif ($expectedBytes -gt 0) {
+            $totalBytes = $expectedBytes
+        }
+
+        $inputStream = $response.Content.ReadAsStreamAsync().GetAwaiter().GetResult()
+        $outputStream = [System.IO.File]::Open($destination, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+        try {
+            $buffer = New-Object byte[] (1024 * 1024)
+            [int64]$downloadedBytes = 0
+            $lastPercent = -10
+            [int64]$lastLoggedBytes = 0
+
+            while (($read = $inputStream.Read($buffer, 0, $buffer.Length)) -gt 0) {
+                $outputStream.Write($buffer, 0, $read)
+                $downloadedBytes += $read
+
+                if ($totalBytes -gt 0) {
+                    $percent = [Math]::Min(100, [int][Math]::Floor(($downloadedBytes * 100.0) / $totalBytes))
+                    if ($percent -ne $lastPercent -and ($percent -ge ($lastPercent + 10) -or $percent -eq 100)) {
+                        Write-Detail ("Download {0}% ({1} / {2})" -f $percent, (Format-Bytes $downloadedBytes), (Format-Bytes $totalBytes))
+                        $lastPercent = $percent
+                    }
+                } elseif (($downloadedBytes - $lastLoggedBytes) -ge (5 * 1024 * 1024)) {
+                    Write-Detail ("Downloaded {0}..." -f (Format-Bytes $downloadedBytes))
+                    $lastLoggedBytes = $downloadedBytes
+                }
+            }
+        } finally {
+            $outputStream.Dispose()
+            $inputStream.Dispose()
+        }
+    } finally {
+        $client.Dispose()
+    }
+}
+
 try {
+    Write-Host ""
+    Write-Host "Matrix IPTV update" -ForegroundColor Green
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    $headers = @{ 'User-Agent' = 'matrix-iptv-cli-updater' }
+    $headers = @{
+        'Accept' = 'application/vnd.github+json'
+        'Cache-Control' = 'no-cache'
+        'User-Agent' = 'matrix-iptv-cli-updater'
+    }
+
+    Write-Step "Resolving latest GitHub release"
     $release = Invoke-RestMethod -Uri 'https://api.github.com/repos/officebeats/matrix-iptv/releases/latest' -Headers $headers
     $targetVersion = [string]$release.tag_name
-    $targetVersion = $targetVersion.TrimStart('v', 'V')
+    $targetVersion = $targetVersion -replace '^[vV]', ''
+    $currentVersion = Get-MatrixVersion $exePath
+    Write-Detail "Current: $currentVersion"
+    Write-Detail "Target : $targetVersion"
+
+    if ($currentVersion -eq $targetVersion) {
+        Write-Host "[+] Matrix IPTV is already up to date." -ForegroundColor Green
+        Write-Step "Relaunching Matrix IPTV"
+        Start-Process -FilePath $exePath -WindowStyle Normal
+        Write-Host "[+] Matrix IPTV $targetVersion is ready." -ForegroundColor Green
+        Remove-Item -Path $MyInvocation.MyCommand.Source -Force -ErrorAction SilentlyContinue
+        exit 0
+    }
+
     $asset = $release.assets | Where-Object { $_.name -eq 'matrix-iptv-windows.exe' } | Select-Object -First 1
     if (-not $asset) {
         throw "Latest release does not include matrix-iptv-windows.exe"
     }
 
-    Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $tempPath -Headers $headers
+    Write-Step "Downloading $($asset.name) from $($release.tag_name)"
+    Download-MatrixAsset $asset.browser_download_url $tempPath $asset.size
+
+    Write-Step "Verifying downloaded binary"
     $downloaded = Get-Item $tempPath
     if ($downloaded.Length -lt $minBinarySize) {
         throw "Downloaded file is too small: $($downloaded.Length) bytes"
@@ -572,19 +721,26 @@ try {
     if ($asset.size -and $downloaded.Length -ne $asset.size) {
         throw "Downloaded file size mismatch: expected $($asset.size), got $($downloaded.Length)"
     }
+    Write-Detail ("File size verified ({0})." -f (Format-Bytes $downloaded.Length))
+
     if ($asset.digest -and $asset.digest.StartsWith('sha256:')) {
         $expectedHash = $asset.digest.Substring(7).ToLowerInvariant()
         $actualHash = (Get-FileHash -Algorithm SHA256 -Path $tempPath).Hash.ToLowerInvariant()
         if ($actualHash -ne $expectedHash) {
             throw "Downloaded binary checksum did not match the GitHub release asset digest"
         }
+        Write-Detail "Checksum verified."
+    } else {
+        Write-Detail "GitHub did not provide a release asset digest; using size and version checks."
     }
 
     $downloadedVersion = Get-MatrixVersion $tempPath
     if ($downloadedVersion -ne $targetVersion) {
         throw "Downloaded binary reports version $downloadedVersion, expected $targetVersion"
     }
+    Write-Detail "Downloaded binary reports version $downloadedVersion."
     
+    Write-Step "Installing update"
     $maxAttempts = 15
     for ($i = 0; $i -lt $maxAttempts; $i++) {
         try {
@@ -595,20 +751,25 @@ try {
             break
         } catch {
             if ($i -eq ($maxAttempts - 1)) { throw }
-            Start-Sleep -Seconds (1 + $i * 0.5)
+            $delay = 1 + $i * 0.5
+            Write-Detail "Executable is still locked. Retrying in $delay seconds..."
+            Start-Sleep -Seconds $delay
         }
     }
 
+    Write-Step "Verifying installed binary"
     $installedVersion = Get-MatrixVersion $exePath
     if ($installedVersion -ne $targetVersion) {
         throw "Installed binary reports version $installedVersion, expected $targetVersion"
     }
+    Write-Detail "Installed binary reports version $installedVersion."
 
     if (Test-Path $backupPath) {
         Remove-Item $backupPath -Force -ErrorAction SilentlyContinue
     }
     
     Start-Sleep -Seconds 1
+    Write-Step "Relaunching Matrix IPTV"
     $maxSpawn = 5
     for ($j = 0; $j -lt $maxSpawn; $j++) {
         try {
@@ -616,9 +777,12 @@ try {
             break
         } catch {
             if ($j -eq ($maxSpawn - 1)) { throw }
-            Start-Sleep -Seconds (1 + $j * 0.5)
+            $delay = 1 + $j * 0.5
+            Write-Detail "Launch was blocked. Retrying in $delay seconds..."
+            Start-Sleep -Seconds $delay
         }
     }
+    Write-Host "[+] Matrix IPTV $targetVersion is ready." -ForegroundColor Green
 } catch {
     Write-Host "`n[!] Update failed: $_" -ForegroundColor Red
     if (Test-Path $tempPath) { Remove-Item $tempPath -Force -ErrorAction SilentlyContinue }
@@ -636,21 +800,20 @@ Remove-Item -Path $MyInvocation.MyCommand.Source -Force -ErrorAction SilentlyCon
     let ps_script = ps_script_template.replace("__EXE_PATH__", &exe_path);
 
     let temp_dir = std::env::temp_dir();
-    let script_path = temp_dir.join("matrix-iptv-update.ps1");
+    let script_path = temp_dir.join(format!("matrix-iptv-update-{}.ps1", std::process::id()));
     std::fs::write(&script_path, ps_script)?;
 
     Command::new("powershell.exe")
         .args([
+            "-NoProfile",
             "-ExecutionPolicy",
             "Bypass",
-            "-WindowStyle",
-            "Hidden",
             "-File",
             &script_path.to_string_lossy(),
         ])
         .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
         .spawn()?;
 
     Ok(())


### PR DESCRIPTION
## Summary

- Adds a status-driven npm updater flow with explicit release resolution, download progress, downloaded-binary verification, install, installed-version verification, and relaunch phases.
- Adds an updater protocol marker so new binaries only delegate to protocol-aware npm wrappers; standalone installs and old wrappers fall back to the fixed Windows self-updater instead of keeping old updater code in the path.
- Updates the Windows standalone fallback script to show visible progress, verify size/checksum/version, retry locked executable swaps, relaunch after verification, and clean up its temp script.
- Quiets successful dependency checks during normal TUI startup while keeping `--check` verbose.

## Why

The existing update handoff could look like the app simply restarted into dependency checks, with no clear indication that the binary was downloaded, verified, installed, and relaunched. Older npm wrappers also remain installed even after the Rust binary updates, so new binaries now bypass wrappers that do not advertise the new updater protocol.

## Validation

- `node --check bin/cli.js`
- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `node bin\cli.js update --target 4.3.11` exercised the Windows npm updater download, checksum, version verification, install, and then the already-current path.
- Parsed the embedded PowerShell updater with `System.Management.Automation.Language.Parser`.
- Executed the generated PowerShell updater against a disposable fake `matrix-iptv.exe` to verify the visible status and relaunch path without touching the real binary.